### PR TITLE
fix(docs): correcting typescript example

### DIFF
--- a/packages/schema-builder/README.md
+++ b/packages/schema-builder/README.md
@@ -64,9 +64,9 @@ export default createSchema({
 Your sanity client's return values can be typed with `s.infer`:
 
 ```typescript
-import sanityClient from "@sanity/client";
+import { createClient } from "@sanity/client";
 
-const client = sanityClient(/* ... */);
+const client = createClient(/* ... */);
 
 // results are automatically typed from the schema!
 const result: s.infer<typeof foo> = await client.fetch(`* [_type == "foo"][0]`);


### PR DESCRIPTION
default export sanityClient is deprecated, Use the named export createClient instead of the default export.
![236842858-d2bd3750-6017-4964-a092-dea7fbd25b71](https://user-images.githubusercontent.com/50793209/237049688-35dea1e0-9763-4c02-a836-9c2053221ab0.png)
