### PR TITLE
[WIP] #78 fix

### DIFF
--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -220,6 +220,7 @@ describe("defineArrayMember", () => {
           defineField({
             name: "tar",
             type: "number",
+            options: undefined,
           }),
         ],
       });

--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -220,7 +220,6 @@ describe("defineArrayMember", () => {
           defineField({
             name: "tar",
             type: "number",
-            options: undefined,
           }),
         ],
       });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,12 +181,12 @@ type ExtractUnionValues<
   T extends NumberOptions | undefined,
   Default
 > = T extends NumberOptions
-  ? T["list"] extends (infer Item)[] // Check if "list" exists and is an array
-    ? Item extends { value: infer Value } // Check if "value" exists in each array item
-      ? Value // Return the type of "value"
-      : Default // If "value" is not present in any array item, return "any"
-    : Default // If "list" is not present, return "any"
-  : Default; // If the input type is "undefined", return "any"
+  ? T["list"] extends (infer Item)[]
+    ? Item extends { value: infer Value }
+      ? Value
+      : Default
+    : Default
+  : Default;
 
 export type NumberDefinition<
   TRequired extends boolean,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,7 +27,6 @@ import type {
   DocumentRule,
   EmailDefinition as EmailDefinitionNative,
   EmailRule,
-  EnumListProps,
   FieldDefinitionBase,
   FileDefinition as FileDefinitionNative,
   FileRule,
@@ -180,18 +179,23 @@ export type GeopointDefinition<TRequired extends boolean> = Merge<
   DefinitionBase<TRequired, Omit<GeopointValue, "_type">, GeopointRule>
 >;
 
-type ExtractUnionValues<T extends NumberOptions> = T["list"][number]["value"];
+type ExtractUnionValues<
+  T extends NumberOptions | undefined,
+  Default
+> = T extends NumberOptions
+  ? T["list"] extends (infer Item)[] // Check if "list" exists and is an array
+    ? Item extends { value: infer Value } // Check if "value" exists in each array item
+      ? Value // Return the type of "value"
+      : Default // If "value" is not present in any array item, return "any"
+    : Default // If "list" is not present, return "any"
+  : Default; // If the input type is "undefined", return "any"
 
 export type NumberDefinition<
   TRequired extends boolean,
   TOptions extends NumberOptions | undefined
 > = Merge<
   NumberDefinitionNative,
-  DefinitionBase<
-    TRequired,
-    TOptions extends EnumListProps ? ExtractUnionValues<TOptions> : number,
-    NumberRule
-  >
+  DefinitionBase<TRequired, ExtractUnionValues<TOptions, number>, NumberRule>
 >;
 
 export type ReferenceDefinition<TRequired extends boolean> = Merge<
@@ -469,7 +473,7 @@ export const defineField = <
   TMemberDefinition extends DefinitionBase<any, any, any> & {
     name?: string;
   },
-  TOptions extends NumberOptions,
+  TOptions extends NumberOptions | undefined = undefined,
   TRequired extends boolean = false
 >(
   schemaField: FieldDefinitionBase &

--- a/packages/types/src/options.test.ts
+++ b/packages/types/src/options.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@jest/globals";
 
 import { expectType } from "@sanity-typed/test-utils";
 
-import { defineField } from ".";
+import { defineArrayMember, defineField } from ".";
 import type { _InferValue } from ".";
 
 describe("number", () => {
@@ -19,5 +19,38 @@ describe("number", () => {
     });
 
     expectType<_InferValue<typeof field>>().toStrictEqual<1 | 2>();
+  });
+
+  it("infers SanityDocument with fields", () => {
+    const field = defineArrayMember({
+      name: "foo",
+      type: "document",
+      fields: [
+        defineField({
+          name: "bar",
+          type: "boolean",
+        }),
+        defineField({
+          name: "tar",
+          type: "number",
+          options: {
+            list: [
+              { value: 1, title: "One" } as const,
+              { value: 2, title: "Two" } as const,
+            ],
+          },
+        }),
+      ],
+    });
+
+    expectType<_InferValue<typeof field>>().toStrictEqual<{
+      _createdAt: string;
+      _id: string;
+      _rev: string;
+      _type: "foo";
+      _updatedAt: string;
+      bar?: boolean;
+      tar?: 1 | 2 | undefined;
+    }>();
   });
 });

--- a/packages/types/src/options.test.ts
+++ b/packages/types/src/options.test.ts
@@ -54,3 +54,55 @@ describe("number", () => {
     }>();
   });
 });
+
+describe("string", () => {
+  it("infers string with options", () => {
+    const field = defineField({
+      name: "foo",
+      type: "string",
+      options: {
+        list: [
+          { title: "Sci-Fi", value: "sci-fi" } as const,
+          { title: "Western", value: "western" } as const,
+        ],
+      },
+    });
+
+    expectType<_InferValue<typeof field>>().toStrictEqual<
+      "sci-fi" | "western"
+    >();
+  });
+
+  it("infers SanityDocument with fields", () => {
+    const field = defineArrayMember({
+      name: "foo",
+      type: "document",
+      fields: [
+        defineField({
+          name: "bar",
+          type: "boolean",
+        }),
+        defineField({
+          name: "tar",
+          type: "string",
+          options: {
+            list: [
+              { title: "Sci-Fi", value: "sci-fi" } as const,
+              { title: "Western", value: "western" } as const,
+            ],
+          },
+        }),
+      ],
+    });
+
+    expectType<_InferValue<typeof field>>().toStrictEqual<{
+      _createdAt: string;
+      _id: string;
+      _rev: string;
+      _type: "foo";
+      _updatedAt: string;
+      bar?: boolean;
+      tar?: "sci-fi" | "western" | undefined;
+    }>();
+  });
+});

--- a/packages/types/src/options.test.ts
+++ b/packages/types/src/options.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "@jest/globals";
+
+import { expectType } from "@sanity-typed/test-utils";
+
+import { defineField } from ".";
+import type { _InferValue } from ".";
+
+describe("number", () => {
+  it("infers number with options", () => {
+    const field = defineField({
+      name: "foo",
+      type: "number",
+      options: {
+        list: [
+          { value: 1, title: "One" } as const,
+          { value: 2, title: "Two" } as const,
+        ],
+      },
+    });
+
+    expectType<_InferValue<typeof field>>().toStrictEqual<1 | 2>();
+  });
+});


### PR DESCRIPTION
## Description

@saiichihashimoto This is a proof of concept for issue #78, narrowing down the `number` and `string` types. A lot of the code is still rough (the `ExtractUnionValues` as an example) but it passes every test. 

The logic can _probably_ just be copied for `Array` type. As well as Augmenting the `defineType()` and `defineArrayMember()` functions in a similar way. 

## Questions
Frustratingly I'm not sure there's a way to get this to work without using `as const` (I could be wrong here so any advice would be great).

Also is this what you imagined the implementation would look like or have I missed the mark? Any feedback would be greatly appreciated


## Test
I've written a couple of brief test in `options.test.ts` but these can eventually go in the main section. 

