### PR TITLE
feat(groq): deref traversal

### DIFF
--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -18,6 +18,7 @@
     "dev": "npm run build -- --no-dts"
   },
   "dependencies": {
+    "@sanity-typed/types": "0.0.0-development",
     "groq-js": "1.1.9",
     "type-fest": "2.19.0"
   },

--- a/packages/groq/src/traversal-operators.test.ts
+++ b/packages/groq/src/traversal-operators.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@jest/globals";
 
 import { expectType } from "@sanity-typed/test-utils";
+import type { ReferenceValue } from "@sanity-typed/types";
 
 import type { Context, ExecuteQuery, Parse, Scope } from ".";
 
@@ -530,11 +531,74 @@ describe("traversal operators", () => {
       base: { type: "Value"; value: false };
       type: "ArrayCoerce";
     }>();
+    expectType<ExecuteQuery<typeof query>>().toStrictEqual<null>();
+  });
+
+  it("@->", () => {
+    const query = "@->";
+
+    expectType<Parse<typeof query>>().toStrictEqual<{
+      base: { type: "This" };
+      type: "Deref";
+    }>();
     expectType<
       ExecuteQuery<
         typeof query,
-        Context<({ _type: "bar" } | { _type: "foo" })[]>
+        Scope<
+          Context<
+            ({ _type: "bar"; value: Bar } | { _type: "foo"; value: Foo })[]
+          >,
+          ReferenceValue<"foo">,
+          never
+        >
       >
-    >().toStrictEqual<null>();
+    >().toStrictEqual<{ _type: "foo"; value: Foo }>();
+  });
+
+  it("@->value", () => {
+    const query = "@->value";
+
+    expectType<Parse<typeof query>>().toStrictEqual<{
+      base: { base: { type: "This" }; type: "Deref" };
+      name: "value";
+      type: "AccessAttribute";
+    }>();
+    expectType<
+      ExecuteQuery<
+        typeof query,
+        Scope<
+          Context<
+            ({ _type: "bar"; value: Bar } | { _type: "foo"; value: Foo })[]
+          >,
+          ReferenceValue<"foo">,
+          never
+        >
+      >
+    >().toStrictEqual<Foo>();
+  });
+
+  it("@[]->value", () => {
+    const query = "@[]->value";
+
+    expectType<Parse<typeof query>>().toStrictEqual<{
+      base: {
+        base: { base: { type: "This" }; type: "ArrayCoerce" };
+        type: "Deref";
+      };
+      name: "value";
+      type: "AccessAttribute";
+    }>();
+    expectType<
+      ExecuteQuery<
+        typeof query,
+        Scope<
+          Context<
+            ({ _type: "bar"; value: Bar } | { _type: "foo"; value: Foo })[]
+          >,
+          ReferenceValue<"foo">[],
+          never
+        >
+      >
+    >().toStrictEqual<Foo[]>();
   });
 });

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -230,6 +230,30 @@ This shouldn't deter you from using it! Under the hood, it's passing all the inp
 
 ## Migrations
 
+### Migrating from 3.x to 4.x
+
+#### Referenced `_type` needs `as const`
+
+For `@sanity-typed/groq` to infer the right types from references, the reference type needs to carry the type it's referencing along with it. Unfortunately, it isn't deriving the literal so an `as const` is needed.
+
+```diff
+const product = defineType({
+  name: "product",
+  type: "document",
+  title: "Product",
+  fields: [
+    defineField({
+      name: "foo",
+      type: "reference",
+-     to: [{ type: "referencedType" }],
++     to: [{ type: "referencedType" as const }],
+    }),
+  ],
+});
+```
+
+This should be easy to identify through typescript errors, follow the suggestions and you should be on your way.
+
 ### Migrating from 2.x to 3.x
 
 #### InferSchemaValues

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,7 +67,7 @@ import type { Merge, RemoveIndexSignature, Simplify } from "type-fest";
 
 import type { TupleOfLength } from "./utils";
 
-// declare const README: unique symbol;
+declare const README: unique symbol;
 declare const required: unique symbol;
 
 type WithRequired<
@@ -193,12 +193,11 @@ export type ReferenceValue<TReferenced extends string> = Merge<
 export type TypeReference<TReferenced extends string> = Merge<
   TypeReferenceNative,
   {
-    // type: string extends TReferenced
-    //   ? TReferenced & {
-    //       [README]: "⛔️ Unfortunately, this needs an `as const` for correct types. ⛔️";
-    //     }
-    //   : TReferenced;
-    type: TReferenced;
+    type: string extends TReferenced
+      ? TReferenced & {
+          [README]: "⛔️ Unfortunately, this needs an `as const` for correct types. ⛔️";
+        }
+      : TReferenced;
   }
 >;
 


### PR DESCRIPTION
BREAKING CHANGE: References in configs need an `as const` on the type
for this to function properly. This changes the promise of being purely
drop in.