### PR TITLE
fix(groq): use MapNode

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,9 @@ jobs:
           cache: "npm"
       - run: npm ci
 
-      - run: npm run build
+      - env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: npm run build
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
           cache: "npm"
       - run: npm ci
 
-      - run: npm run build
+      - env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: npm run build
 
       - run: npm config set workspaces-update false
       - env:

--- a/packages/groq-js/src/evaluate.test.ts
+++ b/packages/groq-js/src/evaluate.test.ts
@@ -145,18 +145,4 @@ describe("evaluate", () => {
     expect(result).toBe("dataset");
     expectType<typeof result>().toStrictEqual<"dataset">();
   });
-
-  it.failing("groq-js readme example", async () => {
-    const query = '*[_type == "user"]{name}';
-    const tree = parse(query);
-    const dataset = [
-      { _type: "user", name: "Michael" },
-      { _type: "company", name: "Bluth Company" },
-    ] as const;
-    const result = await (await evaluate(tree, { dataset })).get();
-
-    // TODO
-    expect(result).toStrictEqual({ name: null });
-    expectType<typeof result>().toStrictEqual<{ name: null }>();
-  });
 });

--- a/packages/groq/src/index.ts
+++ b/packages/groq/src/index.ts
@@ -606,6 +606,36 @@ type ConstantEvaluate<TNode extends ExprNode> =
   // HACK Not sure if giving a never scope works! https://github.com/sanity-io/groq-js/blob/main/src/evaluator/constantEvaluate.ts#L48
   Evaluate<TNode, never>;
 
+type KnownArrayNode =
+  | ArrayCoerceNode
+  | ArrayNode
+  | EverythingNode
+  | FilterNode
+  | MapNode
+  | PipeFuncCallNode
+  | SliceNode;
+
+type MaybeMapBase<TBase extends ExprNode> = TBase extends never
+  ? never
+  : TBase extends KnownArrayNode
+  ? { type: "This" }
+  : TBase;
+
+type MaybeMap<
+  TBase extends ExprNode,
+  TNode extends ExprNode
+> = TBase extends never
+  ? never
+  : TNode extends never
+  ? never
+  : TBase extends KnownArrayNode
+  ? {
+      base: TBase;
+      expr: TNode;
+      type: "Map";
+    }
+  : TNode;
+
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#SquareBracketTraversal
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#AttributeAccess
@@ -645,11 +675,15 @@ type SquareBracketTraversal<
               | (ConstantEvaluate<_Parse<TBracketExpression>> extends never
                   ? never
                   : ConstantEvaluate<_Parse<TBracketExpression>> extends string
-                  ? {
-                      base: _Parse<`${_Prefix}${TBase}`>;
-                      name: ConstantEvaluate<_Parse<TBracketExpression>>;
-                      type: "AccessAttribute";
-                    }
+                  ? // @ts-expect-error -- TODO Type instantiation is excessively deep and possibly infinite.
+                    MaybeMap<
+                      _Parse<`${_Prefix}${TBase}`>,
+                      {
+                        base: MaybeMapBase<_Parse<`${_Prefix}${TBase}`>>;
+                        name: ConstantEvaluate<_Parse<TBracketExpression>>;
+                        type: "AccessAttribute";
+                      }
+                    >
                   : ConstantEvaluate<_Parse<TBracketExpression>> extends number
                   ? {
                       base: _Parse<`${_Prefix}${TBase}`>;
@@ -676,12 +710,31 @@ type AttributeAccess<
           ? never
           : Identifier<TIdentifier> extends never
           ? never
-          : {
-              base: _Parse<`${_Prefix}${TBase}`>;
-              name: TIdentifier;
-              type: "AccessAttribute";
-            })
+          : MaybeMap<
+              _Parse<`${_Prefix}${TBase}`>,
+              {
+                base: MaybeMapBase<_Parse<`${_Prefix}${TBase}`>>;
+                name: TIdentifier;
+                type: "AccessAttribute";
+              }
+            >)
   : never;
+
+type ProjectionInner<
+  TBase extends string,
+  TProjection extends string
+> = _Parse<TBase> extends never
+  ? never
+  : ObjectType<`{${TProjection}}`> extends never
+  ? never
+  : MaybeMap<
+      _Parse<TBase>,
+      {
+        base: MaybeMapBase<_Parse<TBase>>;
+        expr: ObjectType<`{${TProjection}}`>;
+        type: "Projection";
+      }
+    >;
 
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#Projection
@@ -692,27 +745,11 @@ type Projection<
 > = TExpression extends `${infer TBase}|{${infer TProjection}}`
   ?
       | Projection<`${TProjection}}`, `${_Prefix}${TBase}|{`>
-      | (_Parse<`${_Prefix}${TBase}`> extends never
-          ? never
-          : ObjectType<`{${TProjection}}`> extends never
-          ? never
-          : {
-              base: _Parse<`${_Prefix}${TBase}`>;
-              expr: ObjectType<`{${TProjection}}`>;
-              type: "Projection";
-            })
+      | ProjectionInner<`${_Prefix}${TBase}`, TProjection>
   : TExpression extends `${infer TBase}{${infer TProjection}}`
   ?
       | Projection<`${TProjection}}`, `${_Prefix}${TBase}{`>
-      | (_Parse<`${_Prefix}${TBase}`> extends never
-          ? never
-          : ObjectType<`{${TProjection}}`> extends never
-          ? never
-          : {
-              base: _Parse<`${_Prefix}${TBase}`>;
-              expr: ObjectType<`{${TProjection}}`>;
-              type: "Projection";
-            })
+      | ProjectionInner<`${_Prefix}${TBase}`, TProjection>
   : never;
 
 /**
@@ -730,11 +767,17 @@ type Dereference<
           ? { base: _Parse<`${_Prefix}${TBase}`>; type: "Deref" }
           : Identifier<TIdentifier> extends never
           ? never
-          : {
-              base: { base: _Parse<`${_Prefix}${TBase}`>; type: "Deref" };
-              name: TIdentifier;
-              type: "AccessAttribute";
-            })
+          : MaybeMap<
+              _Parse<`${_Prefix}${TBase}`>,
+              {
+                base: {
+                  base: MaybeMapBase<_Parse<`${_Prefix}${TBase}`>>;
+                  type: "Deref";
+                };
+                name: TIdentifier;
+                type: "AccessAttribute";
+              }
+            >)
   : never;
 
 /**
@@ -919,22 +962,6 @@ type EvaluateBaseOrThis<
   ? Evaluate<TBase, TScope>
   : TScope["this"];
 
-type EvaluateAccessAttributeElement<
-  TBase,
-  TName extends string
-> = TBase extends {
-  [key in TName]: infer TValue;
-}
-  ? TValue
-  : null;
-
-type EvaluateAccessAttributeElements<
-  TBases extends any[],
-  TName extends string
-> = {
-  [index in keyof TBases]: EvaluateAccessAttributeElement<TBases[index], TName>;
-};
-
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluateAttributeAccess()
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluateThisAttribute()
@@ -943,15 +970,13 @@ type EvaluateAccessAttribute<
   TNode extends ExprNode,
   TScope extends Scope<Context<readonly any[], any>>
 > = TNode extends AccessAttributeNode
-  ? EvaluateBaseOrThis<TNode, TScope> extends any[]
-    ? EvaluateAccessAttributeElements<
-        EvaluateBaseOrThis<TNode, TScope>,
-        TNode["name"]
-      >
-    : EvaluateAccessAttributeElement<
-        EvaluateBaseOrThis<TNode, TScope>,
-        TNode["name"]
-      >
+  ?
+      | (NonNullable<EvaluateBaseOrThis<TNode, TScope>> extends {
+          [name in TNode["name"]]: infer TValue;
+        }
+          ? TValue
+          : null)
+      | (null extends EvaluateBaseOrThis<TNode, TScope> ? null : never)
   : never;
 
 /**
@@ -1056,24 +1081,6 @@ type EvaluateComparison<TNode extends ExprNode> = TNode extends OpCallNode
     : never
   : never;
 
-type EvaluateDereferenceElement<
-  TRef,
-  TScope extends Scope<Context<readonly any[], any>>
-> = TRef extends ReferenceValue<infer TReferenced>
-  ? TScope["context"]["dataset"] extends (infer TDataset)[]
-    ?
-        | Extract<TDataset, { _type: TReferenced }>
-        | (TRef extends { weak: true } ? null : never)
-    : null
-  : null;
-
-type EvaluateDereferenceElements<
-  TRefs extends any[],
-  TScope extends Scope<Context<readonly any[], any>>
-> = {
-  [index in keyof TRefs]: EvaluateDereferenceElement<TRefs[index], TScope>;
-};
-
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluateDereference()
  */
@@ -1081,9 +1088,15 @@ type EvaluateDereference<
   TNode extends ExprNode,
   TScope extends Scope<Context<readonly any[], any>>
 > = TNode extends DerefNode
-  ? Evaluate<TNode["base"], TScope> extends any[]
-    ? EvaluateDereferenceElements<Evaluate<TNode["base"], TScope>, TScope>
-    : EvaluateDereferenceElement<Evaluate<TNode["base"], TScope>, TScope>
+  ? Evaluate<TNode["base"], TScope> extends ReferenceValue<infer TReferenced>
+    ? TScope["context"]["dataset"] extends (infer TDataset)[]
+      ?
+          | Extract<TDataset, { _type: TReferenced }>
+          | (Evaluate<TNode["base"], TScope> extends { weak: true }
+              ? null
+              : never)
+      : null
+    : null
   : never;
 
 type Not<TBoolean, Enabled extends boolean = true> = TBoolean extends boolean
@@ -1573,6 +1586,30 @@ type EvaluateFuncCall<
 
 type EmptyObject = { [key: string]: never };
 
+type EvaluateMapElements<
+  TBases extends any[],
+  TExpression extends ExprNode,
+  TScope extends Scope<Context<readonly any[], any>>
+> = {
+  [index in keyof TBases]: Evaluate<
+    TExpression,
+    NestedScope<TBases[index], TScope>
+  >;
+};
+
+type EvaluateMap<
+  TNode extends ExprNode,
+  TScope extends Scope<Context<readonly any[], any>>
+> = TNode extends MapNode
+  ? Evaluate<TNode["base"], TScope> extends any[]
+    ? EvaluateMapElements<
+        Evaluate<TNode["base"], TScope>,
+        TNode["expr"],
+        TScope
+      >
+    : null
+  : never;
+
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluatePlus()
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluateMinus()
@@ -1809,24 +1846,6 @@ type EvaluatePos<
     : null
   : never;
 
-type EvaluateProjectionElement<
-  TBase,
-  TExpression extends ExprNode,
-  TScope extends Scope<Context<readonly any[], any>>
-> = Evaluate<TExpression, NestedScope<TBase, TScope>>;
-
-type EvaluateProjectionElements<
-  TBases extends any[],
-  TExpression extends ExprNode,
-  TScope extends Scope<Context<readonly any[], any>>
-> = {
-  [index in keyof TBases]: EvaluateProjectionElement<
-    TBases[index],
-    TExpression,
-    TScope
-  >;
-};
-
 /**
  * @link https://sanity-io.github.io/GROQ/GROQ-1.revision1/#EvaluateProjection()
  */
@@ -1834,17 +1853,10 @@ type EvaluateProjection<
   TNode extends ExprNode,
   TScope extends Scope<Context<readonly any[], any>>
 > = TNode extends ProjectionNode
-  ? Evaluate<TNode["base"], TScope> extends any[]
-    ? EvaluateProjectionElements<
-        Evaluate<TNode["base"], TScope>,
-        TNode["expr"],
-        TScope
-      >
-    : EvaluateProjectionElement<
-        Evaluate<TNode["base"], TScope>,
-        TNode["expr"],
-        TScope
-      >
+  ? Evaluate<
+      TNode["expr"],
+      NestedScope<Evaluate<TNode["base"], TScope>, TScope>
+    >
   : never;
 
 /**
@@ -1884,6 +1896,7 @@ type EvaluateExpression<
   | EvaluateEverything<TNode, TScope>
   | EvaluateFilter<TNode, TScope>
   | EvaluateFuncCall<TNode, TScope>
+  | EvaluateMap<TNode, TScope>
   | EvaluateMath<TNode, TScope>
   | EvaluateNeg<TNode, TScope>
   | EvaluateNot<TNode, TScope>


### PR DESCRIPTION
I had been ignoring it, because we could just map types whenever we
encountered arrays. However, the logic doesn't "just work" whenever it
encounters arrays. It works whenever it's aware of an array at parse
time, not necessarily evaluate time. This makes a difference for things
like parameters. Even though we know their type at evaluate time, we
don't at parse time, so an array leading into a projection should fail.