### PR TITLE
assert SanityClient for castToTyped

### DIFF
--- a/packages/client/_README.md
+++ b/packages/client/_README.md
@@ -43,12 +43,14 @@ import { castToTyped } from "@sanity-typed/client";
 
 import type { SanityValues } from "./sanity.config";
 
+import type { SanityClient } from "sanity";
+
 const client = createClient({
   // ...
 });
 
 // Same function signature as the typed `createClient`
-const typedClient = castToTyped<SanityValues>()(client);
+const typedClient = castToTyped<SanityValues>()(client as SanityClient);
 
 // Also, if you need the config in the client (eg. for queries using $param),
 // you can provide the same config again to include it in the types.


### PR DESCRIPTION
Preview kit introduced a union type for sanity clients `SanityClient | SanityStegaClient`, this just documents the assertion that currently avoids an error.

I am unfamiliar with the `README.md` and `_README.md` approach here, so I'm not sure that I did this as expected. I see `README.md` itself is treated as a binary file and didn't want to mess with any configurations.