### PR TITLE
Strongly typing style, listItem, and markDefs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,6 +148,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: [client, client-mock, faker, groq, groq-js, types, zod]
     steps:

--- a/packages/faker/src/block.test.ts
+++ b/packages/faker/src/block.test.ts
@@ -5,6 +5,7 @@ import { expectType } from "@saiichihashimoto/test-utils";
 import {
   defineArrayMember,
   defineConfig,
+  defineField,
   defineType,
 } from "@sanity-typed/types";
 import type { InferSchemaValues } from "@sanity-typed/types";
@@ -261,7 +262,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts annotations", async () => {
+    it("mocks markDefs", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -275,19 +276,17 @@ describe("block", () => {
                   type: "block",
                   marks: {
                     annotations: [
-                      {
+                      defineArrayMember({
                         name: "internalLink",
                         type: "object",
-                        title: "Internal link",
                         fields: [
-                          {
+                          defineField({
                             name: "reference",
                             type: "reference",
-                            title: "Reference",
-                            to: [{ type: "post" }],
-                          },
+                            to: [{ type: "post" as const }],
+                          }),
                         ],
-                      },
+                      }),
                     ],
                   },
                 }),
@@ -305,7 +304,7 @@ describe("block", () => {
       const zods = sanityConfigToZods(config);
 
       expect(() => zods.foo.parse(fake)).not.toThrow();
-      expectType<(typeof fake)[number]>().toStrictEqual<
+      expectType<(typeof fake)[number]>().toEqual<
         InferSchemaValues<typeof config>["foo"][number]
       >();
     });
@@ -530,7 +529,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts annotations", async () => {
+    it("mocks markDefs", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -541,19 +540,17 @@ describe("block", () => {
               type: "block",
               marks: {
                 annotations: [
-                  {
+                  defineArrayMember({
                     name: "internalLink",
                     type: "object",
-                    title: "Internal link",
                     fields: [
-                      {
+                      defineField({
                         name: "reference",
                         type: "reference",
-                        title: "Reference",
-                        to: [{ type: "post" }],
-                      },
+                        to: [{ type: "post" as const }],
+                      }),
                     ],
-                  },
+                  }),
                 ],
               },
             }),
@@ -569,7 +566,7 @@ describe("block", () => {
       const zods = sanityConfigToZods(config);
 
       expect(() => zods.foo.parse(fake)).not.toThrow();
-      expectType<typeof fake>().toStrictEqual<
+      expectType<typeof fake>().toEqual<
         InferSchemaValues<typeof config>["foo"]
       >();
     });
@@ -590,7 +587,12 @@ describe("block", () => {
               (faker, previous) => ({
                 ...previous,
                 children: [
-                  { _key: "key", _type: "span" as const, text: "foo" },
+                  {
+                    _key: "key",
+                    _type: "span" as const,
+                    marks: ["mark"],
+                    text: "foo",
+                  },
                 ],
               })
             ),
@@ -610,7 +612,7 @@ describe("block", () => {
         InferSchemaValues<typeof config>["foo"]
       >();
       expect(fake).toHaveProperty("children", [
-        { _key: "key", _type: "span" as const, text: "foo" },
+        { _key: "key", _type: "span" as const, marks: ["mark"], text: "foo" },
       ]);
     });
   });

--- a/packages/faker/src/block.test.ts
+++ b/packages/faker/src/block.test.ts
@@ -151,7 +151,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts styles", async () => {
+    it("mocks styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -164,8 +164,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   styles: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -435,7 +435,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts styles", async () => {
+    it("mocks styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -445,8 +445,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               styles: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],

--- a/packages/faker/src/block.test.ts
+++ b/packages/faker/src/block.test.ts
@@ -150,6 +150,165 @@ describe("block", () => {
         InferSchemaValues<typeof config>["foo"][number]
       >();
     });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  styles: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<(typeof fake)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  lists: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<(typeof fake)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    decorators: [
+                      { title: "Foo", value: "foo" },
+                      { title: "Bar", value: "bar" },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<(typeof fake)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    annotations: [
+                      {
+                        name: "internalLink",
+                        type: "object",
+                        title: "Internal link",
+                        fields: [
+                          {
+                            name: "reference",
+                            type: "reference",
+                            title: "Reference",
+                            to: [{ type: "post" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<(typeof fake)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
   });
 
   describe("defineType", () => {
@@ -258,6 +417,145 @@ describe("block", () => {
                 defineArrayMember({ type: "slug" }),
                 defineArrayMember({ type: "geopoint" }),
               ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<typeof fake>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              styles: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<typeof fake>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              lists: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<typeof fake>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                decorators: [
+                  { title: "Foo", value: "foo" },
+                  { title: "Bar", value: "bar" },
+                ],
+              },
+            }),
+          ],
+        },
+      });
+      const sanityFaker = sanityConfigToFakerTyped(config, {
+        faker: { locale: [en, base] },
+      });
+
+      const fake = sanityFaker.foo();
+
+      const zods = sanityConfigToZods(config);
+
+      expect(() => zods.foo.parse(fake)).not.toThrow();
+      expectType<typeof fake>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                annotations: [
+                  {
+                    name: "internalLink",
+                    type: "object",
+                    title: "Internal link",
+                    fields: [
+                      {
+                        name: "reference",
+                        type: "reference",
+                        title: "Reference",
+                        to: [{ type: "post" }],
+                      },
+                    ],
+                  },
+                ],
+              },
             }),
           ],
         },

--- a/packages/faker/src/block.test.ts
+++ b/packages/faker/src/block.test.ts
@@ -151,7 +151,7 @@ describe("block", () => {
       >();
     });
 
-    it("mocks styles", async () => {
+    it("mocks style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -187,7 +187,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts lists", async () => {
+    it("mocks listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -200,8 +200,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   lists: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -435,7 +435,7 @@ describe("block", () => {
       >();
     });
 
-    it("mocks styles", async () => {
+    it("mocks style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -466,7 +466,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts lists", async () => {
+    it("mocks listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -476,8 +476,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               lists: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],

--- a/packages/faker/src/block.test.ts
+++ b/packages/faker/src/block.test.ts
@@ -299,6 +299,7 @@ describe("block", () => {
         faker: { locale: [en, base] },
       });
 
+      // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
       const fake = sanityFaker.foo();
 
       const zods = sanityConfigToZods(config);

--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -13,6 +13,7 @@ import type {
 import type {
   ArrayMemberDefinition,
   ConfigBase,
+  DefinitionBase,
   FieldDefinition,
   MaybeTitledListValue,
   TypeDefinition,
@@ -28,6 +29,9 @@ type SchemaTypeDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -40,6 +44,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any,
@@ -55,6 +60,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any,
@@ -70,6 +76,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any
@@ -110,6 +117,7 @@ const dateAndDatetimeFaker = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -145,7 +153,16 @@ const dateAndDatetimeFaker = <
 };
 
 const dateFaker = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "date",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -162,6 +179,7 @@ const datetimeFaker = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -171,6 +189,7 @@ const datetimeFaker = <
 const numberFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "number",
+    any,
     any,
     any,
     any,
@@ -225,6 +244,7 @@ const numberFaker = <
     any,
     any,
     any,
+    any,
     any
   >
     ? TNumberValue
@@ -273,6 +293,7 @@ const referenceFaker =
       any,
       any,
       any,
+      any,
       any
     >
   >(
@@ -290,6 +311,7 @@ const referenceFaker =
         any,
         any,
         infer TReferenced,
+        any,
         any,
         any,
         any
@@ -332,6 +354,7 @@ const regexFaker = (regex: RegExp) => {
 const stringAndTextFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -394,6 +417,7 @@ const stringFaker = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -403,6 +427,7 @@ const stringFaker = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any,
     any,
@@ -434,7 +459,16 @@ const stringFaker = <
 };
 
 const textFaker = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "text",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) =>
@@ -443,7 +477,16 @@ const textFaker = <
   );
 
 const urlFaker = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "url",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -560,6 +603,7 @@ type MembersFaker<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedFakers extends {
@@ -569,6 +613,7 @@ type MembersFaker<
   faker: Faker,
   index: number
 ) => TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -606,6 +651,7 @@ type MembersFaker<
 
 const membersFaker = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -684,6 +730,7 @@ type ArrayFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -691,6 +738,7 @@ type ArrayFaker<
   }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -712,6 +760,7 @@ type ArrayFaker<
 const arrayFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "array",
+    any,
     any,
     any,
     any,
@@ -779,21 +828,53 @@ const arrayFaker = <
   ) as ArrayFaker<TSchemaType, TAliasedFakers>;
 };
 
-const spanFaker = (faker: Faker) => ({
-  _key: faker.database.mongodbObjectId(),
-  _type: "span" as const,
-  text: faker.lorem.paragraph({ min: 1, max: 5 }),
-  ...(true ? {} : { marks: ["string"] }),
-});
+const spanFaker =
+  <
+    TSchemaType extends SchemaTypeDefinition<
+      "block",
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+  >({
+    marks: { decorators } = {},
+  }: TSchemaType) =>
+  (faker: Faker) => ({
+    _key: faker.database.mongodbObjectId(),
+    _type: "span" as const,
+    marks: faker.helpers
+      .arrayElements(
+        [
+          // TODO Only allow marks that correspond to decorators or markDefs
+          () => faker.database.mongodbObjectId(),
+          ...(decorators?.map(
+            ({ value }) =>
+              () =>
+                value
+          ) ?? [
+            () => "strong",
+            () => "em",
+            () => "code",
+            () => "underline",
+            // TODO https://github.com/sanity-io/sanity/issues/5344
+            () => "strike",
+            () => "strike-through",
+          ]),
+        ],
+        { min: 0, max: 2 }
+      )
+      .map((fn) => fn()),
+    text: faker.lorem.paragraph({ min: 1, max: 5 }),
+  });
 
-const blockFieldsFaker = {
-  _type: "block" as const,
-  markDefs: [{ _key: "key", _type: "type" }],
-};
-
-const blockCustomFaker = <
+const blockFieldsFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "block",
+    any,
     any,
     any,
     any,
@@ -812,6 +893,7 @@ const blockCustomFaker = <
     any,
     infer TBlockStyle,
     any,
+    any,
     any
   >
     ? TBlockStyle
@@ -824,12 +906,14 @@ const blockCustomFaker = <
     any,
     any,
     infer TBlockListItem,
+    any,
     any
   >
     ? TBlockListItem
     : never;
 
   return (faker: Faker) => ({
+    _type: "block" as const,
     ...(faker.datatype.boolean()
       ? {}
       : {
@@ -876,6 +960,7 @@ type BlockFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -885,10 +970,33 @@ type BlockFaker<
   faker: Faker,
   index: number
 ) => Simplify<
-  ReturnType<ReturnType<typeof blockCustomFaker<TSchemaType>>> &
-    typeof blockFieldsFaker & {
-      children: (TSchemaType extends {
-        of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+  ReturnType<ReturnType<typeof blockFieldsFaker<TSchemaType>>> & {
+    children: (TSchemaType extends {
+      of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any
+      >[];
+    }
+      ?
+          | ReturnType<MembersFaker<TMemberDefinitions, TAliasedFakers>>[number]
+          | ReturnType<ReturnType<typeof spanFaker>>
+      : ReturnType<ReturnType<typeof spanFaker>>)[];
+    markDefs: (TSchemaType extends {
+      marks?: {
+        annotations?: infer TBlockMarkAnnotations extends ArrayMemberDefinition<
+          any,
           any,
           any,
           any,
@@ -903,19 +1011,17 @@ type BlockFaker<
           any,
           any
         >[];
-      }
-        ?
-            | ReturnType<
-                MembersFaker<TMemberDefinitions, TAliasedFakers>
-              >[number]
-            | ReturnType<typeof spanFaker>
-        : ReturnType<typeof spanFaker>)[];
+      };
     }
+      ? ReturnType<MembersFaker<TBlockMarkAnnotations, TAliasedFakers>>[number]
+      : never)[];
+  }
 >;
 
 const blockFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "block",
+    any,
     any,
     any,
     any,
@@ -933,12 +1039,13 @@ const blockFaker = <
   documentIdFaker: (type: string | undefined) => (index: number) => string,
   referencedIdFaker: (type: string) => (faker: Faker, index: number) => string
 ): BlockFaker<TSchemaType, TAliasedFakers> => {
-  const blockCustomFakerInstantiated =
-    blockCustomFaker<TSchemaType>(schemaType);
+  const blockFields = blockFieldsFaker(schemaType);
+  const span = spanFaker(schemaType);
 
   return ((faker: Faker, index: number) => {
     type TMemberDefinitions = TSchemaType extends {
       of?: infer TMemberDefinitionsInner extends ArrayMemberDefinition<
+        any,
         any,
         any,
         any,
@@ -964,10 +1071,9 @@ const blockFaker = <
       : faker.number.int({ min: 0, max: length });
 
     return {
-      ...blockFieldsFaker,
-      ...blockCustomFakerInstantiated(faker),
+      ...blockFields(faker),
       children: faker.helpers.shuffle([
-        ...Array.from({ length: numSpans }).map(() => spanFaker(faker)),
+        ...Array.from({ length: numSpans }).map(() => span(faker)),
         ...(numSpans === length
           ? []
           : // TODO https://github.com/saiichihashimoto/sanity-typed/issues/479
@@ -980,6 +1086,18 @@ const blockFaker = <
               { min: length - numSpans, max: length - numSpans }
             )(faker, index)),
       ]),
+      // TODO Only generate markDefs who's _key associates with a span's marks[number]
+      markDefs: !schemaType.marks?.annotations
+        ? []
+        : // TODO https://github.com/saiichihashimoto/sanity-typed/issues/479
+          membersFaker(
+            schemaType.marks.annotations,
+            getFakers,
+            instantiateFakerByPath,
+            documentIdFaker,
+            referencedIdFaker,
+            { min: 1, max: 5 }
+          )(faker, index),
     };
   }) as BlockFaker<TSchemaType, TAliasedFakers>;
 };
@@ -987,6 +1105,7 @@ const blockFaker = <
 type FieldsFaker<
   TSchemaType extends SchemaTypeDefinition<
     "document" | "file" | "image" | "object",
+    any,
     any,
     any,
     any,
@@ -1011,6 +1130,7 @@ type FieldsFaker<
     any,
     any,
     any,
+    any,
     any
   >)[];
 }
@@ -1022,6 +1142,7 @@ type FieldsFaker<
         [Name in Extract<
           TFieldDefinition,
           FieldDefinition<
+            any,
             any,
             any,
             any,
@@ -1059,6 +1180,7 @@ type FieldsFaker<
             any,
             any,
             any,
+            any,
             true
           >
         >["name"]]: ReturnType<
@@ -1080,6 +1202,7 @@ const fieldsFaker = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -1094,6 +1217,7 @@ const fieldsFaker = <
 ): FieldsFaker<TSchemaType, TAliasedFakers> => {
   const fieldsFakers = (
     fields as FieldDefinition<
+      any,
       any,
       any,
       any,
@@ -1144,6 +1268,7 @@ type ObjectFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -1154,6 +1279,7 @@ type ObjectFaker<
 const objectFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "object",
+    any,
     any,
     any,
     any,
@@ -1209,6 +1335,7 @@ type DocumentFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -1225,6 +1352,7 @@ type DocumentFaker<
 const documentFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "document",
+    any,
     any,
     any,
     any,
@@ -1296,6 +1424,7 @@ type FileFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -1312,6 +1441,7 @@ type FileFaker<
 const fileFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "file",
+    any,
     any,
     any,
     any,
@@ -1373,6 +1503,7 @@ type ImageFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -1391,6 +1522,7 @@ type ImageFaker<
       any,
       any,
       any,
+      any,
       infer THotspot extends boolean
     >
       ? THotspot extends true
@@ -1402,6 +1534,7 @@ type ImageFaker<
 const imageFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "image",
+    any,
     any,
     any,
     any,
@@ -1438,6 +1571,7 @@ const imageFaker = <
           any,
           any,
           any,
+          any,
           infer THotspot extends boolean
         >
           ? THotspot
@@ -1451,7 +1585,16 @@ const imageFaker = <
 };
 
 type AliasFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1464,7 +1607,16 @@ type AliasFaker<
 
 const aliasFaker =
   <
-    TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+    TSchemaType extends SchemaTypeDefinition<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >,
     TAliasedFakers extends {
       [name: string]: (index: number) => any;
     }
@@ -1476,7 +1628,16 @@ const aliasFaker =
     getFakers()[type]?.(index) ?? (undefined as unknown);
 
 type SchemaTypeToFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1489,7 +1650,7 @@ type SchemaTypeToFaker<
           typeof dateFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"date", any, any, any, any, any, any>
+              SchemaTypeDefinition<"date", any, any, any, any, any, any, any>
             >
           >
         >
@@ -1498,7 +1659,16 @@ type SchemaTypeToFaker<
           typeof datetimeFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
+              SchemaTypeDefinition<
+                "datetime",
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any
+              >
             >
           >
         >
@@ -1507,7 +1677,7 @@ type SchemaTypeToFaker<
           typeof numberFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"number", any, any, any, any, any, any>
+              SchemaTypeDefinition<"number", any, any, any, any, any, any, any>
             >
           >
         >
@@ -1516,7 +1686,16 @@ type SchemaTypeToFaker<
           typeof referenceFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"reference", any, any, any, any, any, any>
+              SchemaTypeDefinition<
+                "reference",
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any
+              >
             >
           >
         >
@@ -1525,7 +1704,7 @@ type SchemaTypeToFaker<
           typeof stringFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"string", any, any, any, any, any, any>
+              SchemaTypeDefinition<"string", any, any, any, any, any, any, any>
             >
           >
         >
@@ -1534,7 +1713,7 @@ type SchemaTypeToFaker<
           typeof textFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"text", any, any, any, any, any, any>
+              SchemaTypeDefinition<"text", any, any, any, any, any, any, any>
             >
           >
         >
@@ -1543,7 +1722,7 @@ type SchemaTypeToFaker<
           typeof urlFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"url", any, any, any, any, any, any>
+              SchemaTypeDefinition<"url", any, any, any, any, any, any, any>
             >
           >
         >
@@ -1552,7 +1731,7 @@ type SchemaTypeToFaker<
           typeof arrayFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"array", any, any, any, any, any, any>
+              SchemaTypeDefinition<"array", any, any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1562,7 +1741,7 @@ type SchemaTypeToFaker<
           typeof blockFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"block", any, any, any, any, any, any>
+              SchemaTypeDefinition<"block", any, any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1572,7 +1751,7 @@ type SchemaTypeToFaker<
           typeof objectFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"object", any, any, any, any, any, any>
+              SchemaTypeDefinition<"object", any, any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1582,7 +1761,16 @@ type SchemaTypeToFaker<
           typeof documentFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"document", any, any, any, any, any, any>
+              SchemaTypeDefinition<
+                "document",
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any
+              >
             >,
             TAliasedFakers
           >
@@ -1592,7 +1780,7 @@ type SchemaTypeToFaker<
           typeof fileFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"file", any, any, any, any, any, any>
+              SchemaTypeDefinition<"file", any, any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1602,7 +1790,7 @@ type SchemaTypeToFaker<
           typeof imageFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"image", any, any, any, any, any, any>
+              SchemaTypeDefinition<"image", any, any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1614,7 +1802,16 @@ type SchemaTypeToFaker<
 const customFakerFn: unique symbol = Symbol("customFakerFn");
 
 export const customFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType,
   fakerFn: (
@@ -1629,7 +1826,16 @@ export const customFaker = <
 ): TSchemaType => ({ ...schemaType, [customFakerFn]: fakerFn });
 
 const schemaTypeToFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1652,28 +1858,28 @@ const schemaTypeToFaker = <
       ? dateFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"date", any, any, any, any, any, any>
+            SchemaTypeDefinition<"date", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "datetime"
       ? datetimeFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
+            SchemaTypeDefinition<"datetime", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "number"
       ? numberFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"number", any, any, any, any, any, any>
+            SchemaTypeDefinition<"number", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "reference"
       ? referenceFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"reference", any, any, any, any, any, any>
+            SchemaTypeDefinition<"reference", any, any, any, any, any, any, any>
           >,
           referencedIdFaker
         )
@@ -1681,28 +1887,28 @@ const schemaTypeToFaker = <
       ? stringFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"string", any, any, any, any, any, any>
+            SchemaTypeDefinition<"string", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "text"
       ? textFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"text", any, any, any, any, any, any>
+            SchemaTypeDefinition<"text", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "url"
       ? urlFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"url", any, any, any, any, any, any>
+            SchemaTypeDefinition<"url", any, any, any, any, any, any, any>
           >
         )
       : schema.type === "array"
       ? arrayFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"array", any, any, any, any, any, any>
+            SchemaTypeDefinition<"array", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1713,7 +1919,7 @@ const schemaTypeToFaker = <
       ? blockFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"block", any, any, any, any, any, any>
+            SchemaTypeDefinition<"block", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1724,7 +1930,7 @@ const schemaTypeToFaker = <
       ? objectFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"object", any, any, any, any, any, any>
+            SchemaTypeDefinition<"object", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1735,7 +1941,7 @@ const schemaTypeToFaker = <
       ? documentFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"document", any, any, any, any, any, any>
+            SchemaTypeDefinition<"document", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1746,7 +1952,7 @@ const schemaTypeToFaker = <
       ? fileFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"file", any, any, any, any, any, any>
+            SchemaTypeDefinition<"file", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1757,7 +1963,7 @@ const schemaTypeToFaker = <
       ? imageFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"image", any, any, any, any, any, any>
+            SchemaTypeDefinition<"image", any, any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,

--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -19,20 +19,20 @@ import type { IsPlainObject, MaybeArray, Negate } from "@sanity-typed/utils";
 
 type SchemaTypeDefinition<
   TType extends string,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
-  TReferenced extends string
+  TReferenced extends string,
+  THotspot extends boolean
 > =
   | ArrayMemberDefinition<
       TType,
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any,
       any
@@ -42,10 +42,10 @@ type SchemaTypeDefinition<
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any,
       any
@@ -55,10 +55,10 @@ type SchemaTypeDefinition<
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any
     >;
@@ -190,8 +190,8 @@ const numberFaker = <
 
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
-    any,
     infer TNumberValue,
+    any,
     any,
     any
   >
@@ -247,8 +247,8 @@ const referenceFaker =
         "reference",
         any,
         any,
-        any,
-        infer TReferenced
+        infer TReferenced,
+        any
       >
         ? TReferenced
         : never;
@@ -348,8 +348,8 @@ const stringFaker = <
   type TStringValue = TSchemaType extends SchemaTypeDefinition<
     "string",
     any,
-    any,
     infer TStringValue,
+    any,
     any
   >
     ? TStringValue
@@ -1136,10 +1136,10 @@ type ImageFaker<
     ReturnType<typeof imageFieldsFaker> &
     (TSchemaType extends SchemaTypeDefinition<
       "image",
-      infer THotspot,
       any,
       any,
-      any
+      any,
+      infer THotspot extends boolean
     >
       ? THotspot extends true
         ? ReturnType<typeof imageHotspotFaker>
@@ -1173,10 +1173,10 @@ const imageFaker = <
       !schema.options?.hotspot as Negate<
         TSchemaType extends SchemaTypeDefinition<
           "image",
-          infer THotspot,
           any,
           any,
-          any
+          any,
+          infer THotspot extends boolean
         >
           ? THotspot
           : never

--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -231,7 +231,7 @@ const numberFaker = <
     ...(!traversal.negative?.length ? [] : [-epsilon])
   );
 
-  // TODO Handle multiple precisions, somehow
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/536
   const precision = traversal.precision
     ?.map(([limit]) => limit)
     .filter((limit): limit is number => typeof limit === "number")
@@ -319,7 +319,7 @@ const referenceFaker =
         ? TReferenced
         : never;
     }),
-    // TODO weak references and strengthenOnPublish
+    // TODO https://github.com/saiichihashimoto/sanity-typed/issues/358
     ...(true ? {} : { _weak: false }),
     ...(true
       ? {}
@@ -368,7 +368,7 @@ const stringAndTextFaker = <
 ) => {
   const traversal = traverseValidation(schemaType);
 
-  // TODO Handle multiple length, somehow
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/536
   const length = traversal.length
     ?.map(([exactLength]) => exactLength)
     .find(
@@ -397,7 +397,7 @@ const stringAndTextFaker = <
     );
 
   return traversal.regex
-    ? // TODO Combine multiple regex, somehow
+    ? // TODO https://github.com/saiichihashimoto/sanity-typed/issues/536
       regexFaker(traversal.regex![0]![0])
     : traversal.email
     ? (faker: Faker) => faker.internet.email()
@@ -493,13 +493,10 @@ const urlFaker = <
   const traversal = traverseValidation(schemaType);
 
   const {
+    // TODO https://github.com/saiichihashimoto/sanity-typed/issues/539
     allowRelative = false,
-    // TODO allowCredentials = false,
     relativeOnly = false,
-    // TODO scheme: schemaRaw = ["http", "https"],
   } = traversal.uri?.[0]?.[0] ?? {};
-
-  // const schemes = Array.isArray(schemaRaw) ? schemaRaw : [schemaRaw];
 
   return (faker: Faker) => {
     const relative =
@@ -780,7 +777,7 @@ const arrayFaker = <
 ): ArrayFaker<TSchemaType, TAliasedFakers> => {
   const traversal = traverseValidation(schemaType);
 
-  // TODO Handle multiple length, somehow
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/536
   const length = traversal.length
     ?.map(([exactLength]) => exactLength)
     .find(
@@ -849,7 +846,7 @@ const spanFaker =
     marks: faker.helpers
       .arrayElements(
         [
-          // TODO Only allow marks that correspond to decorators or markDefs
+          // TODO https://github.com/saiichihashimoto/sanity-typed/issues/537
           () => faker.database.mongodbObjectId(),
           ...(decorators?.map(
             ({ value }) =>
@@ -917,6 +914,7 @@ const blockFieldsFaker = <
     ...(faker.datatype.boolean()
       ? {}
       : {
+          // TODO https://github.com/saiichihashimoto/sanity-typed/issues/538
           level: 0,
           listItem: typedTernary(
             !lists?.length as Negate<IsStringLiteral<TBlockListItem>>,
@@ -1086,7 +1084,7 @@ const blockFaker = <
               { min: length - numSpans, max: length - numSpans }
             )(faker, index)),
       ]),
-      // TODO Only generate markDefs who's _key associates with a span's marks[number]
+      // TODO https://github.com/saiichihashimoto/sanity-typed/issues/537
       markDefs: !schemaType.marks?.annotations
         ? []
         : // TODO https://github.com/saiichihashimoto/sanity-typed/issues/479
@@ -1390,7 +1388,7 @@ const documentFaker = <
 const assetFaker = (faker: Faker) => ({
   _ref: faker.string.uuid(),
   _type: "reference",
-  // TODO weak references and strengthenOnPublish
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/358
   ...(true ? {} : { _key: "key" }),
   ...(true ? {} : { _weak: false }),
   ...(true

--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -6,6 +6,7 @@ import type { IsNumericLiteral, IsStringLiteral, Simplify } from "type-fest";
 
 import { traverseValidation } from "@sanity-typed/traverse-validation";
 import type {
+  BlockListDefinition,
   BlockStyleDefinition,
   InferSchemaValues,
 } from "@sanity-typed/types";
@@ -26,6 +27,7 @@ type SchemaTypeDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -37,6 +39,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any,
@@ -51,6 +54,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any,
@@ -65,6 +69,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any
@@ -104,6 +109,7 @@ const dateAndDatetimeFaker = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -139,7 +145,7 @@ const dateAndDatetimeFaker = <
 };
 
 const dateFaker = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -149,13 +155,29 @@ const dateFaker = <
 };
 
 const datetimeFaker = <
-  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "datetime",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => dateAndDatetimeFaker(schemaType);
 
 const numberFaker = <
-  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "number",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -199,6 +221,7 @@ const numberFaker = <
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
     infer TNumberValue,
+    any,
     any,
     any,
     any,
@@ -249,6 +272,7 @@ const referenceFaker =
       any,
       any,
       any,
+      any,
       any
     >
   >(
@@ -266,6 +290,7 @@ const referenceFaker =
         any,
         any,
         infer TReferenced,
+        any,
         any,
         any
       >
@@ -307,6 +332,7 @@ const regexFaker = (regex: RegExp) => {
 const stringAndTextFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -361,7 +387,15 @@ const stringAndTextFaker = <
 };
 
 const stringFaker = <
-  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "string",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -369,6 +403,7 @@ const stringFaker = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any,
     any
@@ -399,7 +434,7 @@ const stringFaker = <
 };
 
 const textFaker = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) =>
@@ -408,7 +443,7 @@ const textFaker = <
   );
 
 const urlFaker = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -524,6 +559,7 @@ type MembersFaker<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedFakers extends {
@@ -533,6 +569,7 @@ type MembersFaker<
   faker: Faker,
   index: number
 ) => TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -569,6 +606,7 @@ type MembersFaker<
 
 const membersFaker = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -639,12 +677,21 @@ const noInfinity = (value: number) =>
     : value;
 
 type ArrayFaker<
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "array",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -663,7 +710,15 @@ type ArrayFaker<
   : never;
 
 const arrayFaker = <
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "array",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -733,14 +788,21 @@ const spanFaker = (faker: Faker) => ({
 
 const blockFieldsFaker = {
   _type: "block" as const,
-  ...(true ? {} : { level: 0 }),
-  ...(true ? {} : { listItem: "string" }),
-  ...(true ? {} : { markDefs: [{ _key: "key", _type: "type" }] }),
+  markDefs: [{ _key: "key", _type: "type" }],
 };
 
 const blockCustomFaker = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >({
+  lists,
   styles,
 }: TSchemaType) => {
   type TBlockStyle = TSchemaType extends SchemaTypeDefinition<
@@ -749,12 +811,40 @@ const blockCustomFaker = <
     any,
     any,
     infer TBlockStyle,
+    any,
     any
   >
     ? TBlockStyle
     : never;
 
+  type TBlockListItem = TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    infer TBlockListItem,
+    any
+  >
+    ? TBlockListItem
+    : never;
+
   return (faker: Faker) => ({
+    ...(faker.datatype.boolean()
+      ? {}
+      : {
+          level: 0,
+          listItem: typedTernary(
+            !lists?.length as Negate<IsStringLiteral<TBlockListItem>>,
+            () => faker.helpers.arrayElement(["bullet", "number"] as const),
+            () =>
+              faker.helpers.arrayElement(
+                (lists! as BlockListDefinition<TBlockListItem>[]).map(
+                  ({ value }) => value
+                )
+              )
+          ),
+        }),
     style: typedTernary(
       !styles?.length as Negate<IsStringLiteral<TBlockStyle>>,
       () =>
@@ -779,7 +869,15 @@ const blockCustomFaker = <
 };
 
 type BlockFaker<
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -791,6 +889,7 @@ type BlockFaker<
     typeof blockFieldsFaker & {
       children: (TSchemaType extends {
         of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+          any,
           any,
           any,
           any,
@@ -815,7 +914,15 @@ type BlockFaker<
 >;
 
 const blockFaker = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -832,6 +939,7 @@ const blockFaker = <
   return ((faker: Faker, index: number) => {
     type TMemberDefinitions = TSchemaType extends {
       of?: infer TMemberDefinitionsInner extends ArrayMemberDefinition<
+        any,
         any,
         any,
         any,
@@ -883,6 +991,7 @@ type FieldsFaker<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -890,6 +999,7 @@ type FieldsFaker<
   }
 > = TSchemaType extends {
   fields?: (infer TFieldDefinition extends FieldDefinition<
+    any,
     any,
     any,
     any,
@@ -912,6 +1022,7 @@ type FieldsFaker<
         [Name in Extract<
           TFieldDefinition,
           FieldDefinition<
+            any,
             any,
             any,
             any,
@@ -947,6 +1058,7 @@ type FieldsFaker<
             any,
             any,
             any,
+            any,
             true
           >
         >["name"]]: ReturnType<
@@ -967,6 +1079,7 @@ const fieldsFaker = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -981,6 +1094,7 @@ const fieldsFaker = <
 ): FieldsFaker<TSchemaType, TAliasedFakers> => {
   const fieldsFakers = (
     fields as FieldDefinition<
+      any,
       any,
       any,
       any,
@@ -1023,14 +1137,30 @@ const fieldsFaker = <
 };
 
 type ObjectFaker<
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "object",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
 > = ReturnType<typeof fieldsFaker<TSchemaType, TAliasedFakers>>;
 
 const objectFaker = <
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "object",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1072,7 +1202,15 @@ const documentFieldsFaker =
   };
 
 type DocumentFaker<
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "document",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1085,7 +1223,15 @@ type DocumentFaker<
 >;
 
 const documentFaker = <
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "document",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1143,7 +1289,15 @@ const fileFieldsFaker = (faker: Faker) => ({
 });
 
 type FileFaker<
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "file",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1156,7 +1310,15 @@ type FileFaker<
 >;
 
 const fileFaker = <
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "file",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1204,7 +1366,15 @@ const imageHotspotFaker = (faker: Faker) => ({
 });
 
 type ImageFaker<
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "image",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1220,6 +1390,7 @@ type ImageFaker<
       any,
       any,
       any,
+      any,
       infer THotspot extends boolean
     >
       ? THotspot extends true
@@ -1229,7 +1400,15 @@ type ImageFaker<
 >;
 
 const imageFaker = <
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "image",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1258,6 +1437,7 @@ const imageFaker = <
           any,
           any,
           any,
+          any,
           infer THotspot extends boolean
         >
           ? THotspot
@@ -1271,7 +1451,7 @@ const imageFaker = <
 };
 
 type AliasFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1284,7 +1464,7 @@ type AliasFaker<
 
 const aliasFaker =
   <
-    TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+    TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
     TAliasedFakers extends {
       [name: string]: (index: number) => any;
     }
@@ -1296,7 +1476,7 @@ const aliasFaker =
     getFakers()[type]?.(index) ?? (undefined as unknown);
 
 type SchemaTypeToFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1309,7 +1489,7 @@ type SchemaTypeToFaker<
           typeof dateFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"date", any, any, any, any, any>
+              SchemaTypeDefinition<"date", any, any, any, any, any, any>
             >
           >
         >
@@ -1318,7 +1498,7 @@ type SchemaTypeToFaker<
           typeof datetimeFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"datetime", any, any, any, any, any>
+              SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
             >
           >
         >
@@ -1327,7 +1507,7 @@ type SchemaTypeToFaker<
           typeof numberFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"number", any, any, any, any, any>
+              SchemaTypeDefinition<"number", any, any, any, any, any, any>
             >
           >
         >
@@ -1336,7 +1516,7 @@ type SchemaTypeToFaker<
           typeof referenceFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"reference", any, any, any, any, any>
+              SchemaTypeDefinition<"reference", any, any, any, any, any, any>
             >
           >
         >
@@ -1345,7 +1525,7 @@ type SchemaTypeToFaker<
           typeof stringFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"string", any, any, any, any, any>
+              SchemaTypeDefinition<"string", any, any, any, any, any, any>
             >
           >
         >
@@ -1354,7 +1534,7 @@ type SchemaTypeToFaker<
           typeof textFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"text", any, any, any, any, any>
+              SchemaTypeDefinition<"text", any, any, any, any, any, any>
             >
           >
         >
@@ -1363,7 +1543,7 @@ type SchemaTypeToFaker<
           typeof urlFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"url", any, any, any, any, any>
+              SchemaTypeDefinition<"url", any, any, any, any, any, any>
             >
           >
         >
@@ -1372,7 +1552,7 @@ type SchemaTypeToFaker<
           typeof arrayFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"array", any, any, any, any, any>
+              SchemaTypeDefinition<"array", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1382,7 +1562,7 @@ type SchemaTypeToFaker<
           typeof blockFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"block", any, any, any, any, any>
+              SchemaTypeDefinition<"block", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1392,7 +1572,7 @@ type SchemaTypeToFaker<
           typeof objectFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"object", any, any, any, any, any>
+              SchemaTypeDefinition<"object", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1402,7 +1582,7 @@ type SchemaTypeToFaker<
           typeof documentFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"document", any, any, any, any, any>
+              SchemaTypeDefinition<"document", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1412,7 +1592,7 @@ type SchemaTypeToFaker<
           typeof fileFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"file", any, any, any, any, any>
+              SchemaTypeDefinition<"file", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1422,7 +1602,7 @@ type SchemaTypeToFaker<
           typeof imageFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"image", any, any, any, any, any>
+              SchemaTypeDefinition<"image", any, any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1434,7 +1614,7 @@ type SchemaTypeToFaker<
 const customFakerFn: unique symbol = Symbol("customFakerFn");
 
 export const customFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>
 >(
   schemaType: TSchemaType,
   fakerFn: (
@@ -1449,7 +1629,7 @@ export const customFaker = <
 ): TSchemaType => ({ ...schemaType, [customFakerFn]: fakerFn });
 
 const schemaTypeToFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1472,28 +1652,28 @@ const schemaTypeToFaker = <
       ? dateFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"date", any, any, any, any, any>
+            SchemaTypeDefinition<"date", any, any, any, any, any, any>
           >
         )
       : schema.type === "datetime"
       ? datetimeFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"datetime", any, any, any, any, any>
+            SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
           >
         )
       : schema.type === "number"
       ? numberFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"number", any, any, any, any, any>
+            SchemaTypeDefinition<"number", any, any, any, any, any, any>
           >
         )
       : schema.type === "reference"
       ? referenceFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"reference", any, any, any, any, any>
+            SchemaTypeDefinition<"reference", any, any, any, any, any, any>
           >,
           referencedIdFaker
         )
@@ -1501,28 +1681,28 @@ const schemaTypeToFaker = <
       ? stringFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"string", any, any, any, any, any>
+            SchemaTypeDefinition<"string", any, any, any, any, any, any>
           >
         )
       : schema.type === "text"
       ? textFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"text", any, any, any, any, any>
+            SchemaTypeDefinition<"text", any, any, any, any, any, any>
           >
         )
       : schema.type === "url"
       ? urlFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"url", any, any, any, any, any>
+            SchemaTypeDefinition<"url", any, any, any, any, any, any>
           >
         )
       : schema.type === "array"
       ? arrayFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"array", any, any, any, any, any>
+            SchemaTypeDefinition<"array", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1533,7 +1713,7 @@ const schemaTypeToFaker = <
       ? blockFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"block", any, any, any, any, any>
+            SchemaTypeDefinition<"block", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1544,7 +1724,7 @@ const schemaTypeToFaker = <
       ? objectFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"object", any, any, any, any, any>
+            SchemaTypeDefinition<"object", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1555,7 +1735,7 @@ const schemaTypeToFaker = <
       ? documentFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"document", any, any, any, any, any>
+            SchemaTypeDefinition<"document", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1566,7 +1746,7 @@ const schemaTypeToFaker = <
       ? fileFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"file", any, any, any, any, any>
+            SchemaTypeDefinition<"file", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1577,7 +1757,7 @@ const schemaTypeToFaker = <
       ? imageFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"image", any, any, any, any, any>
+            SchemaTypeDefinition<"image", any, any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,

--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -5,7 +5,10 @@ import RandExp from "randexp";
 import type { IsNumericLiteral, IsStringLiteral, Simplify } from "type-fest";
 
 import { traverseValidation } from "@sanity-typed/traverse-validation";
-import type { InferSchemaValues } from "@sanity-typed/types";
+import type {
+  BlockStyleDefinition,
+  InferSchemaValues,
+} from "@sanity-typed/types";
 import type {
   ArrayMemberDefinition,
   ConfigBase,
@@ -22,6 +25,7 @@ type SchemaTypeDefinition<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -32,6 +36,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any,
@@ -45,6 +50,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any,
@@ -58,6 +64,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any
@@ -96,6 +103,7 @@ const dateAndDatetimeFaker = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -131,7 +139,7 @@ const dateAndDatetimeFaker = <
 };
 
 const dateFaker = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -141,13 +149,13 @@ const dateFaker = <
 };
 
 const datetimeFaker = <
-  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => dateAndDatetimeFaker(schemaType);
 
 const numberFaker = <
-  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -193,6 +201,7 @@ const numberFaker = <
     infer TNumberValue,
     any,
     any,
+    any,
     any
   >
     ? TNumberValue
@@ -233,7 +242,16 @@ const numberFaker = <
 };
 
 const referenceFaker =
-  <TSchemaType extends SchemaTypeDefinition<"reference", any, any, any, any>>(
+  <
+    TSchemaType extends SchemaTypeDefinition<
+      "reference",
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+  >(
     schemaType: TSchemaType,
     referencedIdFaker: (type: string) => (faker: Faker, index: number) => string
   ) =>
@@ -248,6 +266,7 @@ const referenceFaker =
         any,
         any,
         infer TReferenced,
+        any,
         any
       >
         ? TReferenced
@@ -288,6 +307,7 @@ const regexFaker = (regex: RegExp) => {
 const stringAndTextFaker = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -341,7 +361,7 @@ const stringAndTextFaker = <
 };
 
 const stringFaker = <
-  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -349,6 +369,7 @@ const stringFaker = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any
   >
@@ -378,7 +399,7 @@ const stringFaker = <
 };
 
 const textFaker = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) =>
@@ -387,7 +408,7 @@ const textFaker = <
   );
 
 const urlFaker = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -502,6 +523,7 @@ type MembersFaker<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedFakers extends {
@@ -511,6 +533,7 @@ type MembersFaker<
   faker: Faker,
   index: number
 ) => TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -546,6 +569,7 @@ type MembersFaker<
 
 const membersFaker = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -615,12 +639,13 @@ const noInfinity = (value: number) =>
     : value;
 
 type ArrayFaker<
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -638,7 +663,7 @@ type ArrayFaker<
   : never;
 
 const arrayFaker = <
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -710,12 +735,51 @@ const blockFieldsFaker = {
   _type: "block" as const,
   ...(true ? {} : { level: 0 }),
   ...(true ? {} : { listItem: "string" }),
-  ...(true ? {} : { style: "normal" }),
   ...(true ? {} : { markDefs: [{ _key: "key", _type: "type" }] }),
 };
 
+const blockCustomFaker = <
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>
+>({
+  styles,
+}: TSchemaType) => {
+  type TBlockStyle = TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    infer TBlockStyle,
+    any
+  >
+    ? TBlockStyle
+    : never;
+
+  return (faker: Faker) => ({
+    style: typedTernary(
+      !styles?.length as Negate<IsStringLiteral<TBlockStyle>>,
+      () =>
+        faker.helpers.arrayElement([
+          "blockquote",
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+          "normal",
+        ] as const),
+      () =>
+        faker.helpers.arrayElement(
+          (styles! as BlockStyleDefinition<TBlockStyle>[]).map(
+            ({ value }) => value
+          )
+        )
+    ),
+  });
+};
+
 type BlockFaker<
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -723,44 +787,52 @@ type BlockFaker<
   faker: Faker,
   index: number
 ) => Simplify<
-  typeof blockFieldsFaker & {
-    children: (TSchemaType extends {
-      of?: infer TMemberDefinitions extends ArrayMemberDefinition<
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any
-      >[];
+  ReturnType<ReturnType<typeof blockCustomFaker<TSchemaType>>> &
+    typeof blockFieldsFaker & {
+      children: (TSchemaType extends {
+        of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any
+        >[];
+      }
+        ?
+            | ReturnType<
+                MembersFaker<TMemberDefinitions, TAliasedFakers>
+              >[number]
+            | ReturnType<typeof spanFaker>
+        : ReturnType<typeof spanFaker>)[];
     }
-      ?
-          | ReturnType<MembersFaker<TMemberDefinitions, TAliasedFakers>>[number]
-          | ReturnType<typeof spanFaker>
-      : ReturnType<typeof spanFaker>)[];
-  }
 >;
 
 const blockFaker = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
 >(
-  { of }: TSchemaType,
+  schemaType: TSchemaType,
   getFakers: () => TAliasedFakers,
   instantiateFakerByPath: ReturnType<typeof instantiateFaker>,
   documentIdFaker: (type: string | undefined) => (index: number) => string,
   referencedIdFaker: (type: string) => (faker: Faker, index: number) => string
-): BlockFaker<TSchemaType, TAliasedFakers> =>
-  ((faker: Faker, index: number) => {
+): BlockFaker<TSchemaType, TAliasedFakers> => {
+  const blockCustomFakerInstantiated =
+    blockCustomFaker<TSchemaType>(schemaType);
+
+  return ((faker: Faker, index: number) => {
     type TMemberDefinitions = TSchemaType extends {
       of?: infer TMemberDefinitionsInner extends ArrayMemberDefinition<
+        any,
         any,
         any,
         any,
@@ -776,7 +848,7 @@ const blockFaker = <
     }
       ? TMemberDefinitionsInner
       : never;
-    const members = (of as TMemberDefinitions) ?? [];
+    const members = (schemaType.of as TMemberDefinitions) ?? [];
 
     const length = faker.number.int({ min: 1, max: 5 });
     const numSpans = !members.length
@@ -785,6 +857,7 @@ const blockFaker = <
 
     return {
       ...blockFieldsFaker,
+      ...blockCustomFakerInstantiated(faker),
       children: faker.helpers.shuffle([
         ...Array.from({ length: numSpans }).map(() => spanFaker(faker)),
         ...(numSpans === length
@@ -801,10 +874,12 @@ const blockFaker = <
       ]),
     };
   }) as BlockFaker<TSchemaType, TAliasedFakers>;
+};
 
 type FieldsFaker<
   TSchemaType extends SchemaTypeDefinition<
     "document" | "file" | "image" | "object",
+    any,
     any,
     any,
     any,
@@ -815,6 +890,7 @@ type FieldsFaker<
   }
 > = TSchemaType extends {
   fields?: (infer TFieldDefinition extends FieldDefinition<
+    any,
     any,
     any,
     any,
@@ -836,6 +912,7 @@ type FieldsFaker<
         [Name in Extract<
           TFieldDefinition,
           FieldDefinition<
+            any,
             any,
             any,
             any,
@@ -869,6 +946,7 @@ type FieldsFaker<
             any,
             any,
             any,
+            any,
             true
           >
         >["name"]]: ReturnType<
@@ -888,6 +966,7 @@ const fieldsFaker = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedFakers extends {
@@ -902,6 +981,7 @@ const fieldsFaker = <
 ): FieldsFaker<TSchemaType, TAliasedFakers> => {
   const fieldsFakers = (
     fields as FieldDefinition<
+      any,
       any,
       any,
       any,
@@ -943,14 +1023,14 @@ const fieldsFaker = <
 };
 
 type ObjectFaker<
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
 > = ReturnType<typeof fieldsFaker<TSchemaType, TAliasedFakers>>;
 
 const objectFaker = <
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -992,7 +1072,7 @@ const documentFieldsFaker =
   };
 
 type DocumentFaker<
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1005,7 +1085,7 @@ type DocumentFaker<
 >;
 
 const documentFaker = <
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1063,7 +1143,7 @@ const fileFieldsFaker = (faker: Faker) => ({
 });
 
 type FileFaker<
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1076,7 +1156,7 @@ type FileFaker<
 >;
 
 const fileFaker = <
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1124,7 +1204,7 @@ const imageHotspotFaker = (faker: Faker) => ({
 });
 
 type ImageFaker<
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1139,6 +1219,7 @@ type ImageFaker<
       any,
       any,
       any,
+      any,
       infer THotspot extends boolean
     >
       ? THotspot extends true
@@ -1148,7 +1229,7 @@ type ImageFaker<
 >;
 
 const imageFaker = <
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1176,6 +1257,7 @@ const imageFaker = <
           any,
           any,
           any,
+          any,
           infer THotspot extends boolean
         >
           ? THotspot
@@ -1189,7 +1271,7 @@ const imageFaker = <
 };
 
 type AliasFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1202,7 +1284,7 @@ type AliasFaker<
 
 const aliasFaker =
   <
-    TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+    TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
     TAliasedFakers extends {
       [name: string]: (index: number) => any;
     }
@@ -1214,7 +1296,7 @@ const aliasFaker =
     getFakers()[type]?.(index) ?? (undefined as unknown);
 
 type SchemaTypeToFaker<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1227,7 +1309,7 @@ type SchemaTypeToFaker<
           typeof dateFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"date", any, any, any, any>
+              SchemaTypeDefinition<"date", any, any, any, any, any>
             >
           >
         >
@@ -1236,7 +1318,7 @@ type SchemaTypeToFaker<
           typeof datetimeFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"datetime", any, any, any, any>
+              SchemaTypeDefinition<"datetime", any, any, any, any, any>
             >
           >
         >
@@ -1245,7 +1327,7 @@ type SchemaTypeToFaker<
           typeof numberFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"number", any, any, any, any>
+              SchemaTypeDefinition<"number", any, any, any, any, any>
             >
           >
         >
@@ -1254,7 +1336,7 @@ type SchemaTypeToFaker<
           typeof referenceFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"reference", any, any, any, any>
+              SchemaTypeDefinition<"reference", any, any, any, any, any>
             >
           >
         >
@@ -1263,7 +1345,7 @@ type SchemaTypeToFaker<
           typeof stringFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"string", any, any, any, any>
+              SchemaTypeDefinition<"string", any, any, any, any, any>
             >
           >
         >
@@ -1272,7 +1354,7 @@ type SchemaTypeToFaker<
           typeof textFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"text", any, any, any, any>
+              SchemaTypeDefinition<"text", any, any, any, any, any>
             >
           >
         >
@@ -1281,7 +1363,7 @@ type SchemaTypeToFaker<
           typeof urlFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"url", any, any, any, any>
+              SchemaTypeDefinition<"url", any, any, any, any, any>
             >
           >
         >
@@ -1290,7 +1372,7 @@ type SchemaTypeToFaker<
           typeof arrayFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"array", any, any, any, any>
+              SchemaTypeDefinition<"array", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1300,7 +1382,7 @@ type SchemaTypeToFaker<
           typeof blockFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"block", any, any, any, any>
+              SchemaTypeDefinition<"block", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1310,7 +1392,7 @@ type SchemaTypeToFaker<
           typeof objectFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"object", any, any, any, any>
+              SchemaTypeDefinition<"object", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1320,7 +1402,7 @@ type SchemaTypeToFaker<
           typeof documentFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"document", any, any, any, any>
+              SchemaTypeDefinition<"document", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1330,7 +1412,7 @@ type SchemaTypeToFaker<
           typeof fileFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"file", any, any, any, any>
+              SchemaTypeDefinition<"file", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1340,7 +1422,7 @@ type SchemaTypeToFaker<
           typeof imageFaker<
             Extract<
               TSchemaType,
-              SchemaTypeDefinition<"image", any, any, any, any>
+              SchemaTypeDefinition<"image", any, any, any, any, any>
             >,
             TAliasedFakers
           >
@@ -1352,7 +1434,7 @@ type SchemaTypeToFaker<
 const customFakerFn: unique symbol = Symbol("customFakerFn");
 
 export const customFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>
 >(
   schemaType: TSchemaType,
   fakerFn: (
@@ -1367,7 +1449,7 @@ export const customFaker = <
 ): TSchemaType => ({ ...schemaType, [customFakerFn]: fakerFn });
 
 const schemaTypeToFaker = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedFakers extends {
     [name: string]: (index: number) => any;
   }
@@ -1390,28 +1472,28 @@ const schemaTypeToFaker = <
       ? dateFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"date", any, any, any, any>
+            SchemaTypeDefinition<"date", any, any, any, any, any>
           >
         )
       : schema.type === "datetime"
       ? datetimeFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"datetime", any, any, any, any>
+            SchemaTypeDefinition<"datetime", any, any, any, any, any>
           >
         )
       : schema.type === "number"
       ? numberFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"number", any, any, any, any>
+            SchemaTypeDefinition<"number", any, any, any, any, any>
           >
         )
       : schema.type === "reference"
       ? referenceFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"reference", any, any, any, any>
+            SchemaTypeDefinition<"reference", any, any, any, any, any>
           >,
           referencedIdFaker
         )
@@ -1419,28 +1501,28 @@ const schemaTypeToFaker = <
       ? stringFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"string", any, any, any, any>
+            SchemaTypeDefinition<"string", any, any, any, any, any>
           >
         )
       : schema.type === "text"
       ? textFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"text", any, any, any, any>
+            SchemaTypeDefinition<"text", any, any, any, any, any>
           >
         )
       : schema.type === "url"
       ? urlFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"url", any, any, any, any>
+            SchemaTypeDefinition<"url", any, any, any, any, any>
           >
         )
       : schema.type === "array"
       ? arrayFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"array", any, any, any, any>
+            SchemaTypeDefinition<"array", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1451,7 +1533,7 @@ const schemaTypeToFaker = <
       ? blockFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"block", any, any, any, any>
+            SchemaTypeDefinition<"block", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1462,7 +1544,7 @@ const schemaTypeToFaker = <
       ? objectFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"object", any, any, any, any>
+            SchemaTypeDefinition<"object", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1473,7 +1555,7 @@ const schemaTypeToFaker = <
       ? documentFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"document", any, any, any, any>
+            SchemaTypeDefinition<"document", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1484,7 +1566,7 @@ const schemaTypeToFaker = <
       ? fileFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"file", any, any, any, any>
+            SchemaTypeDefinition<"file", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,
@@ -1495,7 +1577,7 @@ const schemaTypeToFaker = <
       ? imageFaker(
           schema as Extract<
             TSchemaType,
-            SchemaTypeDefinition<"image", any, any, any, any>
+            SchemaTypeDefinition<"image", any, any, any, any, any>
           >,
           getFakers,
           prefixedInstantiateFakerByPath,

--- a/packages/traverse-validation/src/index.ts
+++ b/packages/traverse-validation/src/index.ts
@@ -24,6 +24,7 @@ type SchemaTypeDefinition<TType extends string> =
       any,
       any,
       any,
+      any,
       any
     >
   | FieldDefinition<
@@ -39,10 +40,12 @@ type SchemaTypeDefinition<TType extends string> =
       any,
       any,
       any,
+      any,
       any
     >
   | TypeDefinition<
       TType,
+      any,
       any,
       any,
       any,

--- a/packages/traverse-validation/src/index.ts
+++ b/packages/traverse-validation/src/index.ts
@@ -23,6 +23,7 @@ type SchemaTypeDefinition<TType extends string> =
       any,
       any,
       any,
+      any,
       any
     >
   | FieldDefinition<
@@ -37,9 +38,23 @@ type SchemaTypeDefinition<TType extends string> =
       any,
       any,
       any,
+      any,
       any
     >
-  | TypeDefinition<TType, any, any, any, any, any, any, any, any, any, any>;
+  | TypeDefinition<
+      TType,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >;
 
 type ArgsObject = {
   [key in keyof UnionToIntersection<

--- a/packages/traverse-validation/src/index.ts
+++ b/packages/traverse-validation/src/index.ts
@@ -22,10 +22,24 @@ type SchemaTypeDefinition<TType extends string> =
       any,
       any,
       any,
+      any,
       any
     >
-  | FieldDefinition<TType, any, any, any, any, any, any, any, any, any, any>
-  | TypeDefinition<TType, any, any, any, any, any, any, any, any, any>;
+  | FieldDefinition<
+      TType,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+  | TypeDefinition<TType, any, any, any, any, any, any, any, any, any, any>;
 
 type ArgsObject = {
   [key in keyof UnionToIntersection<

--- a/packages/traverse-validation/src/index.ts
+++ b/packages/traverse-validation/src/index.ts
@@ -11,9 +11,21 @@ import type {
 import type { MaybeArray } from "@sanity-typed/utils";
 
 type SchemaTypeDefinition<TType extends string> =
-  | ArrayMemberDefinition<TType, any, any, any, any, any, any, any, any>
-  | FieldDefinition<TType, any, any, any, any, any, any, any, any>
-  | TypeDefinition<TType, any, any, any, any, any, any, any>;
+  | ArrayMemberDefinition<
+      TType,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+  | FieldDefinition<TType, any, any, any, any, any, any, any, any, any, any>
+  | TypeDefinition<TType, any, any, any, any, any, any, any, any, any>;
 
 type ArgsObject = {
   [key in keyof UnionToIntersection<

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -25,6 +25,8 @@ Infer Sanity Document Types from Sanity Schemas
 - [Considerations](#considerations)
   - [Types match config but not actual documents](#types-match-config-but-not-actual-documents)
 - [Breaking Changes](#breaking-changes)
+  - [5 to 6](#5-to-6)
+    - [Block fields require `as const`](#block-fields-require-as-const)
   - [4 to 5](#4-to-5)
     - [Removed `_InferValue` and `AliasValue`](#removed-_infervalue-and-aliasvalue)
   - [3 to 4](#3-to-4)
@@ -316,6 +318,30 @@ This can get unwieldy although, if you're diligent about data migrations of your
 <!-- <<<<<< END INCLUDED FILE (markdown): SOURCE docs/considerations/types-vs-content-lake.md -->
 
 ## Breaking Changes
+
+### 5 to 6
+
+#### Block fields require `as const`
+
+Similar to references, to get the right types out of a block, we'll need a few `as const`
+
+```diff
+const foo = defineType({
+  name: "foo",
+  type: "array",
+  of: [
+    defineArrayMember({
+      type: "block",
+      styles: [
+-       { title: "Foo", value: "foo" },
++       { title: "Foo", value: "foo" as const },
+-       { title: "Bar", value: "bar" },
++       { title: "Bar", value: "bar" as const },
+      ],
+    }),
+  ],
+});
+```
 
 ### 4 to 5
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -323,7 +323,7 @@ This can get unwieldy although, if you're diligent about data migrations of your
 
 #### Block fields require `as const`
 
-Similar to references, to get the right types out of a block, we'll need a few `as const`
+Similar to references, to get the right types out of a block, we'll need `as const` with `styles[number].value` and `lists[number].value`. Also, `marks.annotations[number]` now requires typing like other array members, ie `defineArrayMember`:
 
 ```diff
 const foo = defineType({
@@ -338,6 +338,32 @@ const foo = defineType({
 -       { title: "Bar", value: "bar" },
 +       { title: "Bar", value: "bar" as const },
       ],
+      lists: [
+-       { title: "Foo", value: "foo" },
++       { title: "Foo", value: "foo" as const },
+-       { title: "Bar", value: "bar" },
++       { title: "Bar", value: "bar" as const },
+      ],
+      marks: {
+        annotations: [
+-         {
++         defineArrayMember({
+            name: "internalLink",
+            type: "object",
+            fields: [
+-             {
++             defineField({
+                name: "reference",
+                type: "reference",
+-               to: [{ type: "post" }],
++               to: [{ type: "post" as const }],
+-             },
++             }),
+            ],
+-         },
++         }),
+        ],
+      },
     }),
   ],
 });

--- a/packages/types/_README.md
+++ b/packages/types/_README.md
@@ -183,7 +183,7 @@ const nav = defineType({
 
 #### Block fields require `as const`
 
-Similar to references, to get the right types out of a block, we'll need a few `as const`
+Similar to references, to get the right types out of a block, we'll need `as const` with `styles[number].value` and `lists[number].value`. Also, `marks.annotations[number]` now requires typing like other array members, ie `defineArrayMember`:
 
 ```diff
 const foo = defineType({
@@ -198,6 +198,32 @@ const foo = defineType({
 -       { title: "Bar", value: "bar" },
 +       { title: "Bar", value: "bar" as const },
       ],
+      lists: [
+-       { title: "Foo", value: "foo" },
++       { title: "Foo", value: "foo" as const },
+-       { title: "Bar", value: "bar" },
++       { title: "Bar", value: "bar" as const },
+      ],
+      marks: {
+        annotations: [
+-         {
++         defineArrayMember({
+            name: "internalLink",
+            type: "object",
+            fields: [
+-             {
++             defineField({
+                name: "reference",
+                type: "reference",
+-               to: [{ type: "post" }],
++               to: [{ type: "post" as const }],
+-             },
++             }),
+            ],
+-         },
++         }),
+        ],
+      },
     }),
   ],
 });

--- a/packages/types/_README.md
+++ b/packages/types/_README.md
@@ -179,6 +179,30 @@ const nav = defineType({
 
 ## Breaking Changes
 
+### 5 to 6
+
+#### Block fields require `as const`
+
+Similar to references, to get the right types out of a block, we'll need a few `as const`
+
+```diff
+const foo = defineType({
+  name: "foo",
+  type: "array",
+  of: [
+    defineArrayMember({
+      type: "block",
+      styles: [
+-       { title: "Foo", value: "foo" },
++       { title: "Foo", value: "foo" as const },
+-       { title: "Bar", value: "bar" },
++       { title: "Bar", value: "bar" as const },
+      ],
+    }),
+  ],
+});
+```
+
 ### 4 to 5
 
 #### Removed `_InferValue` and `AliasValue`

--- a/packages/types/src/block.test.ts
+++ b/packages/types/src/block.test.ts
@@ -36,8 +36,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -111,8 +111,8 @@ describe("block", () => {
           | (SlugValue & { _key: string })
         )[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -165,8 +165,8 @@ describe("block", () => {
           | (SlugValue & { _key: string })
         )[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -182,7 +182,7 @@ describe("block", () => {
       }>();
     });
 
-    it("infers styles", async () => {
+    it("infers style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -215,8 +215,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -224,7 +224,7 @@ describe("block", () => {
       }>();
     });
 
-    it("accepts lists", async () => {
+    it("infers listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -237,8 +237,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   lists: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -257,8 +257,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bar" | "foo";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -309,8 +309,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -372,8 +372,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -442,8 +442,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -515,8 +515,8 @@ describe("block", () => {
           | (SlugValue & { _key: string })
         )[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -563,8 +563,8 @@ describe("block", () => {
           | (SlugValue & { _key: string })
         )[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -580,7 +580,7 @@ describe("block", () => {
       }>();
     });
 
-    it("infers styles", async () => {
+    it("infers style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -607,8 +607,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -616,7 +616,7 @@ describe("block", () => {
       }>();
     });
 
-    it("accepts lists", async () => {
+    it("infers listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -626,8 +626,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               lists: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],
@@ -643,8 +643,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bar" | "foo";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -689,8 +689,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
@@ -746,8 +746,8 @@ describe("block", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];

--- a/packages/types/src/block.test.ts
+++ b/packages/types/src/block.test.ts
@@ -41,7 +41,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -108,7 +116,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -154,11 +170,19 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
-    it("accepts styles", async () => {
+    it("infers styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -171,8 +195,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   styles: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -196,7 +220,7 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style: "bar" | "foo";
       }>();
     });
 
@@ -238,7 +262,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -282,7 +314,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -337,7 +377,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
   });
@@ -399,7 +447,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -464,7 +520,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -504,11 +568,19 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
-    it("accepts styles", async () => {
+    it("infers styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -518,8 +590,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               styles: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],
@@ -540,7 +612,7 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style: "bar" | "foo";
       }>();
     });
 
@@ -576,7 +648,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -614,7 +694,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
 
@@ -663,7 +751,15 @@ describe("block", () => {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }>();
     });
   });

--- a/packages/types/src/block.test.ts
+++ b/packages/types/src/block.test.ts
@@ -4,6 +4,7 @@ import type { GeopointValue } from "sanity";
 
 import { defineArrayMember, defineConfig, defineField, defineType } from ".";
 import type { InferSchemaValues, SlugValue } from ".";
+import type { referenced } from "./internal";
 
 describe("block", () => {
   describe("defineArrayMember", () => {
@@ -32,15 +33,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -105,17 +103,14 @@ describe("block", () => {
           | {
               _key: string;
               _type: "span";
-              marks?: string[];
+              marks: string[];
               text: string;
             }
           | (SlugValue & { _key: string })
         )[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -158,7 +153,7 @@ describe("block", () => {
           | {
               _key: string;
               _type: "span";
-              marks?: string[];
+              marks: string[];
               text: string;
             }
           | (GeopointValue & { _key: string })
@@ -166,10 +161,7 @@ describe("block", () => {
         )[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -211,15 +203,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style: "bar" | "foo";
       }>();
     });
@@ -253,15 +242,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bar" | "foo";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -305,15 +291,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -326,7 +309,7 @@ describe("block", () => {
       }>();
     });
 
-    it("accepts annotations", async () => {
+    it("infers markDefs", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -340,19 +323,17 @@ describe("block", () => {
                   type: "block",
                   marks: {
                     annotations: [
-                      {
+                      defineArrayMember({
                         name: "internalLink",
                         type: "object",
-                        title: "Internal link",
                         fields: [
-                          {
+                          defineField({
                             name: "reference",
                             type: "reference",
-                            title: "Reference",
-                            to: [{ type: "post" }],
-                          },
+                            to: [{ type: "post" as const }],
+                          }),
                         ],
-                      },
+                      }),
                     ],
                   },
                 }),
@@ -368,14 +349,30 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
         markDefs: {
           _key: string;
-          _type: string;
+          _type: "internalLink";
+          reference?: {
+            _ref: string;
+            _strengthenOnPublish?: {
+              template?: {
+                id: string;
+                params: {
+                  [key: string]: boolean | number | string;
+                };
+              };
+              type: string;
+              weak?: boolean;
+            };
+            _type: "reference";
+            _weak?: boolean;
+            [referenced]: "post";
+          };
         }[];
         style:
           | "blockquote"
@@ -438,15 +435,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -509,17 +503,14 @@ describe("block", () => {
           | {
               _key: string;
               _type: "span";
-              marks?: string[];
+              marks: string[];
               text: string;
             }
           | (SlugValue & { _key: string })
         )[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -556,7 +547,7 @@ describe("block", () => {
           | {
               _key: string;
               _type: "span";
-              marks?: string[];
+              marks: string[];
               text: string;
             }
           | (GeopointValue & { _key: string })
@@ -564,10 +555,7 @@ describe("block", () => {
         )[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -603,15 +591,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style: "bar" | "foo";
       }>();
     });
@@ -639,15 +624,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bar" | "foo";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -685,15 +667,12 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"
@@ -706,7 +685,7 @@ describe("block", () => {
       }>();
     });
 
-    it("accepts annotations", async () => {
+    it("infers markDefs", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -717,19 +696,17 @@ describe("block", () => {
               type: "block",
               marks: {
                 annotations: [
-                  {
+                  defineArrayMember({
                     name: "internalLink",
                     type: "object",
-                    title: "Internal link",
                     fields: [
-                      {
+                      defineField({
                         name: "reference",
                         type: "reference",
-                        title: "Reference",
-                        to: [{ type: "post" }],
-                      },
+                        to: [{ type: "post" as const }],
+                      }),
                     ],
-                  },
+                  }),
                 ],
               },
             }),
@@ -742,14 +719,30 @@ describe("block", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;
         listItem?: "bullet" | "number";
         markDefs: {
           _key: string;
-          _type: string;
+          _type: "internalLink";
+          reference?: {
+            _ref: string;
+            _strengthenOnPublish?: {
+              template?: {
+                id: string;
+                params: {
+                  [key: string]: boolean | number | string;
+                };
+              };
+              type: string;
+              weak?: boolean;
+            };
+            _type: "reference";
+            _weak?: boolean;
+            [referenced]: "post";
+          };
         }[];
         style:
           | "blockquote"

--- a/packages/types/src/block.test.ts
+++ b/packages/types/src/block.test.ts
@@ -157,6 +157,189 @@ describe("block", () => {
         style?: string;
       }>();
     });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  styles: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"][number]>().toEqual<{
+        _key: string;
+        _type: "block";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  lists: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"][number]>().toEqual<{
+        _key: string;
+        _type: "block";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    decorators: [
+                      { title: "Foo", value: "foo" },
+                      { title: "Bar", value: "bar" },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"][number]>().toEqual<{
+        _key: string;
+        _type: "block";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    annotations: [
+                      {
+                        name: "internalLink",
+                        type: "object",
+                        title: "Internal link",
+                        fields: [
+                          {
+                            name: "reference",
+                            type: "reference",
+                            title: "Reference",
+                            to: [{ type: "post" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"][number]>().toEqual<{
+        _key: string;
+        _type: "block";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
   });
 
   describe("defineField", () => {
@@ -315,6 +498,165 @@ describe("block", () => {
           | (GeopointValue & { _key: string })
           | (SlugValue & { _key: string })
         )[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              styles: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"]>().toEqual<{
+        _type: "foo";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              lists: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"]>().toEqual<{
+        _type: "foo";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                decorators: [
+                  { title: "Foo", value: "foo" },
+                  { title: "Bar", value: "bar" },
+                ],
+              },
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"]>().toEqual<{
+        _type: "foo";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
+        level?: number;
+        listItem?: string;
+        markDefs?: {
+          _key: string;
+          _type: string;
+        }[];
+        style?: string;
+      }>();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                annotations: [
+                  {
+                    name: "internalLink",
+                    type: "object",
+                    title: "Internal link",
+                    fields: [
+                      {
+                        name: "reference",
+                        type: "reference",
+                        title: "Reference",
+                        to: [{ type: "post" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            }),
+          ],
+        },
+      });
+
+      expectType<InferSchemaValues<typeof config>["foo"]>().toEqual<{
+        _type: "foo";
+        children: {
+          _key: string;
+          _type: "span";
+          marks?: string[];
+          text: string;
+        }[];
         level?: number;
         listItem?: string;
         markDefs?: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,7 +23,6 @@ export type {
   ObjectDefinition,
   PluginOptions,
   PortableTextBlock,
-  PortableTextMarkDefinition,
   PortableTextSpan,
   ReferenceDefinition,
   ReferenceValue,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   ArrayDefinition,
   BlockDefinition,
+  BlockStyleDefinition,
   BooleanDefinition,
   Config,
   CrossDatasetReferenceDefinition,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,7 +16,6 @@ export type {
   ImageDefinition,
   ImageValue,
   InferSchemaValues,
-  IntrinsicDefinitions,
   IntrinsicTypeName,
   NumberDefinition,
   ObjectDefinition,
@@ -32,6 +31,7 @@ export type {
   SlugValue,
   StringDefinition,
   TextDefinition,
+  TitledListValue,
   TypeAliasDefinition,
   UrlDefinition,
 } from "./internal";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   ArrayDefinition,
   BlockDefinition,
+  BlockListDefinition,
   BlockStyleDefinition,
   BooleanDefinition,
   Config,

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -65,7 +65,6 @@ import type {
   StringRule,
   TextDefinition as TextDefinitionNative,
   TextRule,
-  TitledListValue,
   TypeAliasDefinition as TypeAliasDefinitionNative,
   TypeReference as TypeReferenceNative,
   UrlDefinition as UrlDefinitionNative,
@@ -198,22 +197,28 @@ export type GeopointDefinition<TRequired extends boolean> = MergeOld<
   DefinitionBase<TRequired, GeopointValue, GeopointRule>
 >;
 
+export type TitledListValue<T> = {
+  _key?: string;
+  title: string;
+  value: T;
+};
+
 export type MaybeTitledListValue<T> = T | TitledListValue<T>;
 
 export type NumberDefinition<
-  TOptionsHelper,
+  TNumberValue extends number,
   TRequired extends boolean
 > = MergeOld<
   NumberDefinitionNative,
   DefinitionBase<
     TRequired,
-    TOptionsHelper & number,
-    RewriteValue<TOptionsHelper & number, NumberRule>
+    TNumberValue,
+    RewriteValue<TNumberValue, NumberRule>
   > & {
     options?: MergeOld<
       NumberOptions,
       {
-        list?: MaybeTitledListValue<TOptionsHelper>[];
+        list?: MaybeTitledListValue<TNumberValue>[];
       }
     >;
   }
@@ -306,15 +311,15 @@ export type RegexRule<Rule extends RuleDef<Rule, any>> = MergeOld<
 >;
 
 export type StringDefinition<
-  TOptionsHelper,
+  TStringValue extends string,
   TRequired extends boolean
 > = MergeOld<
   StringDefinitionNative,
   DefinitionBase<
     TRequired,
-    TOptionsHelper & string,
+    TStringValue,
     RewriteValue<
-      TOptionsHelper & string,
+      TStringValue,
       // @ts-expect-error -- IDK
       RegexRule<StringRule>
     >
@@ -322,7 +327,7 @@ export type StringDefinition<
     options?: MergeOld<
       StringOptions,
       {
-        list?: MaybeTitledListValue<TOptionsHelper>[];
+        list?: MaybeTitledListValue<TStringValue>[];
       }
     >;
   }
@@ -565,8 +570,10 @@ export type ImageDefinition<
   }
 >;
 
-export type IntrinsicDefinitions<
+type IntrinsicDefinitions<
   TOptionsHelper,
+  TNumberValue extends number,
+  TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -586,17 +593,17 @@ export type IntrinsicDefinitions<
   file: FileDefinition<TFieldDefinition, TRequired>;
   geopoint: GeopointDefinition<TRequired>;
   image: ImageDefinition<TOptionsHelper, TFieldDefinition, TRequired>;
-  number: NumberDefinition<TOptionsHelper, TRequired>;
+  number: NumberDefinition<TNumberValue, TRequired>;
   object: ObjectDefinition<TFieldDefinition, TRequired>;
   reference: ReferenceDefinition<TReferenced, TRequired>;
   slug: SlugDefinition<TRequired>;
-  string: StringDefinition<TOptionsHelper, TRequired>;
+  string: StringDefinition<TStringValue, TRequired>;
   text: TextDefinition<TRequired>;
   url: UrlDefinition<TRequired>;
 };
 
 export type IntrinsicTypeName = Simplify<
-  keyof IntrinsicDefinitions<any, any, any, any, any>
+  keyof IntrinsicDefinitions<any, any, any, any, any, any, any>
 >;
 
 declare const aliasedType: unique symbol;
@@ -609,6 +616,8 @@ export type TypeAliasDefinition<
   TType extends string,
   TAlias extends IntrinsicTypeName,
   TOptionsHelper,
+  TNumberValue extends number,
+  TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -622,6 +631,8 @@ export type TypeAliasDefinition<
     options?: TAlias extends IntrinsicTypeName
       ? IntrinsicDefinitions<
           TOptionsHelper,
+          TNumberValue,
+          TStringValue,
           TReferenced,
           TFieldDefinition,
           TMemberDefinition,
@@ -639,6 +650,8 @@ export type ArrayMemberDefinition<
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
   TOptionsHelper,
+  TNumberValue extends number,
+  TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -658,6 +671,8 @@ export type ArrayMemberDefinition<
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
               TOptionsHelper,
+              TNumberValue,
+              TStringValue,
               TReferenced,
               TFieldDefinition,
               TMemberDefinition,
@@ -666,6 +681,8 @@ export type ArrayMemberDefinition<
               ? MergeOld<
                   IntrinsicDefinitions<
                     TOptionsHelper,
+                    TNumberValue,
+                    TStringValue,
                     TReferenced,
                     TFieldDefinition,
                     TMemberDefinition,
@@ -691,6 +708,8 @@ export type ArrayMemberDefinition<
                 >
               : IntrinsicDefinitions<
                   TOptionsHelper,
+                  TNumberValue,
+                  TStringValue,
                   TReferenced,
                   TFieldDefinition,
                   TMemberDefinition,
@@ -707,6 +726,8 @@ export type ArrayMemberDefinition<
             TType,
             TAlias,
             TOptionsHelper,
+            TNumberValue,
+            TStringValue,
             TReferenced,
             TFieldDefinition,
             TMemberDefinition,
@@ -743,6 +764,8 @@ export const makeDefineArrayMember =
     TName extends string,
     TAlias extends IntrinsicTypeName,
     TStrict extends StrictDefinition,
+    const TNumberValue extends number,
+    const TStringValue extends string,
     TReferenced extends string,
     const TOptionsHelper,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
@@ -759,6 +782,8 @@ export const makeDefineArrayMember =
       TAlias,
       TStrict,
       TOptionsHelper,
+      TNumberValue,
+      TStringValue,
       TReferenced,
       TFieldDefinition,
       TMemberDefinition,
@@ -779,6 +804,8 @@ export type FieldDefinition<
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
   TOptionsHelper,
+  TNumberValue extends number,
+  TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -799,6 +826,8 @@ export type FieldDefinition<
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
               TOptionsHelper,
+              TNumberValue,
+              TStringValue,
               TReferenced,
               TFieldDefinition,
               TMemberDefinition,
@@ -813,6 +842,8 @@ export type FieldDefinition<
         TType,
         TAlias,
         TOptionsHelper,
+        TNumberValue,
+        TStringValue,
         TReferenced,
         TFieldDefinition,
         TMemberDefinition,
@@ -830,6 +861,8 @@ export const defineField = <
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
   const TOptionsHelper,
+  const TNumberValue extends number,
+  const TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -846,6 +879,8 @@ export const defineField = <
     TAlias,
     TStrict,
     TOptionsHelper,
+    TNumberValue,
+    TStringValue,
     TReferenced,
     TFieldDefinition,
     TMemberDefinition,
@@ -860,6 +895,8 @@ export type TypeDefinition<
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
   TOptionsHelper,
+  TNumberValue extends number,
+  TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -874,6 +911,8 @@ export type TypeDefinition<
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
               TOptionsHelper,
+              TNumberValue,
+              TStringValue,
               TReferenced,
               TFieldDefinition,
               TMemberDefinition,
@@ -888,6 +927,8 @@ export type TypeDefinition<
         TType,
         TAlias,
         TOptionsHelper,
+        TNumberValue,
+        TStringValue,
         TReferenced,
         TFieldDefinition,
         TMemberDefinition,
@@ -904,6 +945,8 @@ export const defineType = <
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
   const TOptionsHelper,
+  const TNumberValue extends number,
+  const TStringValue extends string,
   TReferenced extends string,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -919,6 +962,8 @@ export const defineType = <
     TAlias,
     TStrict,
     TOptionsHelper,
+    TNumberValue,
+    TStringValue,
     TReferenced,
     TFieldDefinition,
     TMemberDefinition
@@ -932,6 +977,8 @@ export const defineType = <
 
 export type ConfigBase<
   TTypeDefinition extends TypeDefinition<
+    any,
+    any,
     any,
     any,
     any,
@@ -970,6 +1017,8 @@ export type PluginOptions<
     any,
     any,
     any,
+    any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -978,6 +1027,8 @@ export type PluginOptions<
 
 export const definePlugin = <
   TTypeDefinition extends TypeDefinition<
+    any,
+    any,
     any,
     any,
     any,
@@ -1009,6 +1060,8 @@ type WorkspaceOptions<
     any,
     any,
     any,
+    any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1019,6 +1072,8 @@ type WorkspaceOptions<
 
 export type Config<
   TTypeDefinition extends TypeDefinition<
+    any,
+    any,
     any,
     any,
     any,
@@ -1041,6 +1096,8 @@ export type Config<
 
 export const defineConfig = <
   TTypeDefinition extends TypeDefinition<
+    any,
+    any,
     any,
     any,
     any,
@@ -1101,6 +1158,8 @@ export type InferSchemaValues<
         AliasValue<TName>,
         InferSchemaValues<TPluginOptions> & {
           [TDefinition in TypeDefinition<
+            any,
+            any,
             any,
             any,
             any,
@@ -1175,6 +1234,8 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
+                any,
                 any
               >
             : never)
@@ -1190,6 +1251,8 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
+                any,
                 any
               >
             : never)
@@ -1201,6 +1264,8 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 TName,
                 NonNullable<TAlias>,
                 TStrict,
+                any,
+                any,
                 any,
                 any,
                 any,
@@ -1221,6 +1286,8 @@ export const castFromTyped = <Typed>(typed: Typed) =>
     infer TName extends string,
     infer TAlias extends IntrinsicTypeName,
     infer TStrict extends StrictDefinition,
+    any,
+    any,
     any,
     any,
     any,
@@ -1245,6 +1312,8 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         any,
         any,
         any,
+        any,
+        any,
         any
       >
     ? ReturnType<
@@ -1262,6 +1331,8 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         infer TName extends string,
         infer TAlias extends IntrinsicTypeName,
         infer TStrict extends StrictDefinition,
+        any,
+        any,
         any,
         any,
         any,

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -381,6 +381,7 @@ export type PortableTextBlock<
 > = {
   _type: "block";
   children: C[];
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/538
   level?: number;
   listItem?: L;
   markDefs: M[];

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -14,6 +14,7 @@ import type {
   ArrayDefinition as ArrayDefinitionNative,
   ArrayRule,
   BlockDefinition as BlockDefinitionNative,
+  BlockListDefinition as BlockListDefinitionNative,
   BlockRule,
   BlockStyleDefinition as BlockStyleDefinitionNative,
   BooleanDefinition as BooleanDefinitionNative,
@@ -366,7 +367,7 @@ export type ArrayDefinition<
   }
 >;
 
-type PortableTextBlockStyleDefault =
+type PortableTextStyleDefault =
   | "blockquote"
   | "h1"
   | "h2"
@@ -375,6 +376,8 @@ type PortableTextBlockStyleDefault =
   | "h5"
   | "h6"
   | "normal";
+
+type PortableTextListItemDefault = "bullet" | "number";
 
 export type PortableTextMarkDefinition =
   OmitIndexSignature<PortableTextMarkDefinitionNative>;
@@ -391,7 +394,7 @@ export type PortableTextBlock<
   children: C[];
   level?: number;
   listItem?: L;
-  markDefs?: M[];
+  markDefs: M[];
   style: S;
 };
 // TODO PortableTextBlock is too complex for some reason https://github.com/saiichihashimoto/sanity-typed/issues/415
@@ -404,8 +407,16 @@ export type BlockStyleDefinition<Value extends string> = MergeOld<
   }
 >;
 
+export type BlockListDefinition<Value extends string> = MergeOld<
+  BlockListDefinitionNative,
+  {
+    value: Value;
+  }
+>;
+
 export type BlockDefinition<
   TBlockStyle extends string,
+  TBlockListItem extends string,
   TMemberDefinition extends DefinitionBase<any, any, any> & { name?: string },
   TRequired extends boolean
 > = MergeOld<
@@ -418,7 +429,10 @@ export type BlockDefinition<
       | (TMemberDefinition extends never
           ? never
           : InferRawValue<TMemberDefinition> & { _key: string }),
-      string extends TBlockStyle ? PortableTextBlockStyleDefault : TBlockStyle
+      string extends TBlockStyle ? PortableTextStyleDefault : TBlockStyle,
+      string extends TBlockListItem
+        ? PortableTextListItemDefault
+        : TBlockListItem
     >,
     RewriteValue<
       PortableTextBlock<
@@ -427,11 +441,22 @@ export type BlockDefinition<
         | (TMemberDefinition extends never
             ? never
             : InferRawValue<TMemberDefinition> & { _key: string }),
-        string extends TBlockStyle ? PortableTextBlockStyleDefault : TBlockStyle
+        string extends TBlockStyle ? PortableTextStyleDefault : TBlockStyle,
+        string extends TBlockListItem
+          ? PortableTextListItemDefault
+          : TBlockListItem
       >,
       BlockRule
     >
   > & {
+    lists?: BlockListDefinition<
+      TBlockListItem &
+        (IsStringLiteral<TBlockListItem> extends false
+          ? {
+              [README]: "⛔️ Unfortunately, this needs an `as const` for correct types. ⛔️";
+            }
+          : unknown)
+    >[];
     of?: TupleOfLength<TMemberDefinition, 1>;
     styles?: BlockStyleDefinition<
       TBlockStyle &
@@ -598,6 +623,7 @@ type IntrinsicDefinitions<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -607,7 +633,12 @@ type IntrinsicDefinitions<
   TRequired extends boolean
 > = {
   array: ArrayDefinition<TMemberDefinition, TRequired>;
-  block: BlockDefinition<TBlockStyle, TMemberDefinition, TRequired>;
+  block: BlockDefinition<
+    TBlockStyle,
+    TBlockListItem,
+    TMemberDefinition,
+    TRequired
+  >;
   boolean: BooleanDefinition<TRequired>;
   crossDatasetReference: CrossDatasetReferenceDefinition<TRequired>;
   date: DateDefinition<TRequired>;
@@ -627,7 +658,7 @@ type IntrinsicDefinitions<
 };
 
 export type IntrinsicTypeName = Simplify<
-  keyof IntrinsicDefinitions<any, any, any, any, any, any, any, any>
+  keyof IntrinsicDefinitions<any, any, any, any, any, any, any, any, any>
 >;
 
 declare const aliasedType: unique symbol;
@@ -643,6 +674,7 @@ export type TypeAliasDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -659,6 +691,7 @@ export type TypeAliasDefinition<
           TStringValue,
           TReferenced,
           TBlockStyle,
+          TBlockListItem,
           THotspot,
           TFieldDefinition,
           TMemberDefinition,
@@ -679,6 +712,7 @@ export type ArrayMemberDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -701,6 +735,7 @@ export type ArrayMemberDefinition<
               TStringValue,
               TReferenced,
               TBlockStyle,
+              TBlockListItem,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -712,6 +747,7 @@ export type ArrayMemberDefinition<
                     TStringValue,
                     TReferenced,
                     TBlockStyle,
+                    TBlockListItem,
                     THotspot,
                     TFieldDefinition,
                     TMemberDefinition,
@@ -740,6 +776,7 @@ export type ArrayMemberDefinition<
                   TStringValue,
                   TReferenced,
                   TBlockStyle,
+                  TBlockListItem,
                   THotspot,
                   TFieldDefinition,
                   TMemberDefinition,
@@ -759,6 +796,7 @@ export type ArrayMemberDefinition<
             TStringValue,
             TReferenced,
             TBlockStyle,
+            TBlockListItem,
             THotspot,
             TFieldDefinition,
             TMemberDefinition,
@@ -799,6 +837,7 @@ export const makeDefineArrayMember =
     const TStringValue extends string,
     const TReferenced extends string,
     const TBlockStyle extends string,
+    const TBlockListItem extends string,
     const THotspot extends boolean,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
       name: string;
@@ -817,6 +856,7 @@ export const makeDefineArrayMember =
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       TFieldDefinition,
       TMemberDefinition,
@@ -840,6 +880,7 @@ export type FieldDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -863,6 +904,7 @@ export type FieldDefinition<
               TStringValue,
               TReferenced,
               TBlockStyle,
+              TBlockListItem,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -880,6 +922,7 @@ export type FieldDefinition<
         TStringValue,
         TReferenced,
         TBlockStyle,
+        TBlockListItem,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -900,6 +943,7 @@ export const defineField = <
   const TStringValue extends string,
   const TReferenced extends string,
   const TBlockStyle extends string,
+  const TBlockListItem extends string,
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -919,6 +963,7 @@ export const defineField = <
     TStringValue,
     TReferenced,
     TBlockStyle,
+    TBlockListItem,
     THotspot,
     TFieldDefinition,
     TMemberDefinition,
@@ -936,6 +981,7 @@ export type TypeDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -953,6 +999,7 @@ export type TypeDefinition<
               TStringValue,
               TReferenced,
               TBlockStyle,
+              TBlockListItem,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -970,6 +1017,7 @@ export type TypeDefinition<
         TStringValue,
         TReferenced,
         TBlockStyle,
+        TBlockListItem,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -989,6 +1037,7 @@ export const defineType = <
   const TStringValue extends string,
   const TReferenced extends string,
   const TBlockStyle extends string,
+  const TBlockListItem extends string,
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -1007,6 +1056,7 @@ export const defineType = <
     TStringValue,
     TReferenced,
     TBlockStyle,
+    TBlockListItem,
     THotspot,
     TFieldDefinition,
     TMemberDefinition
@@ -1020,6 +1070,7 @@ export const defineType = <
 
 export type ConfigBase<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1064,6 +1115,7 @@ export type PluginOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1072,6 +1124,7 @@ export type PluginOptions<
 
 export const definePlugin = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1107,6 +1160,7 @@ type WorkspaceOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1117,6 +1171,7 @@ type WorkspaceOptions<
 
 export type Config<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1142,6 +1197,7 @@ export type Config<
 
 export const defineConfig = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1205,6 +1261,7 @@ export type InferSchemaValues<
         AliasValue<TName>,
         InferSchemaValues<TPluginOptions> & {
           [TDefinition in TypeDefinition<
+            any,
             any,
             any,
             any,
@@ -1285,6 +1342,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1296,6 +1354,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 TName,
                 NonNullable<TAlias>,
                 TStrict,
+                any,
                 any,
                 any,
                 any,
@@ -1320,6 +1379,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1337,6 +1397,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
     infer TName extends string,
     infer TAlias extends IntrinsicTypeName,
     infer TStrict extends StrictDefinition,
+    any,
     any,
     any,
     any,
@@ -1367,6 +1428,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         any,
         any,
         any,
+        any,
         any
       >
     ? ReturnType<
@@ -1384,6 +1446,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         infer TName extends string,
         infer TAlias extends IntrinsicTypeName,
         infer TStrict extends StrictDefinition,
+        any,
         any,
         any,
         any,

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -1,5 +1,5 @@
 import type {
-  PortableTextMarkDefinition as PortableTextMarkDefinitionNative,
+  PortableTextMarkDefinition,
   PortableTextSpan as PortableTextSpanNative,
   TypedObject,
 } from "@portabletext/types";
@@ -15,6 +15,7 @@ import type {
   ArrayRule,
   BlockDefinition as BlockDefinitionNative,
   BlockListDefinition as BlockListDefinitionNative,
+  BlockMarksDefinition,
   BlockRule,
   BlockStyleDefinition as BlockStyleDefinitionNative,
   BooleanDefinition as BooleanDefinitionNative,
@@ -128,7 +129,7 @@ type ValidationBuilder<
   rule: WithRequired<false, Rule>
 ) => MaybeArray<WithRequired<TRequired | false, Rule>>;
 
-type DefinitionBase<
+export type DefinitionBase<
   TRequired extends boolean,
   Value,
   Rule extends RuleDef<Rule, Value>
@@ -367,25 +368,13 @@ export type ArrayDefinition<
   }
 >;
 
-type PortableTextStyleDefault =
-  | "blockquote"
-  | "h1"
-  | "h2"
-  | "h3"
-  | "h4"
-  | "h5"
-  | "h6"
-  | "normal";
-
-type PortableTextListItemDefault = "bullet" | "number";
-
-export type PortableTextMarkDefinition =
-  OmitIndexSignature<PortableTextMarkDefinitionNative>;
-
-export type PortableTextSpan = SetRequired<PortableTextSpanNative, "_key">;
+export type PortableTextSpan = SetRequired<
+  PortableTextSpanNative,
+  "_key" | "marks"
+>;
 
 export type PortableTextBlock<
-  M extends PortableTextMarkDefinitionNative = PortableTextMarkDefinition,
+  M extends PortableTextMarkDefinition = PortableTextMarkDefinition,
   C extends TypedObject = PortableTextSpan,
   S extends string = string,
   L extends string = string
@@ -417,6 +406,9 @@ export type BlockListDefinition<Value extends string> = MergeOld<
 export type BlockDefinition<
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   TMemberDefinition extends DefinitionBase<any, any, any> & { name?: string },
   TRequired extends boolean
 > = MergeOld<
@@ -424,27 +416,35 @@ export type BlockDefinition<
   DefinitionBase<
     TRequired,
     PortableTextBlock<
-      PortableTextMarkDefinition,
+      DefinitionBase<any, any, any> & {
+        name?: string;
+      } extends TBlockMarkAnnotation
+        ? never
+        : InferRawValue<TBlockMarkAnnotation> & { _key: string },
       | PortableTextSpan
       | (TMemberDefinition extends never
           ? never
           : InferRawValue<TMemberDefinition> & { _key: string }),
-      string extends TBlockStyle ? PortableTextStyleDefault : TBlockStyle,
-      string extends TBlockListItem
-        ? PortableTextListItemDefault
-        : TBlockListItem
+      string extends TBlockStyle
+        ? "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal"
+        : TBlockStyle,
+      string extends TBlockListItem ? "bullet" | "number" : TBlockListItem
     >,
     RewriteValue<
       PortableTextBlock<
-        PortableTextMarkDefinition,
+        DefinitionBase<any, any, any> & {
+          name?: string;
+        } extends TBlockMarkAnnotation
+          ? never
+          : InferRawValue<TBlockMarkAnnotation> & { _key: string },
         | PortableTextSpan
         | (TMemberDefinition extends never
             ? never
             : InferRawValue<TMemberDefinition> & { _key: string }),
-        string extends TBlockStyle ? PortableTextStyleDefault : TBlockStyle,
-        string extends TBlockListItem
-          ? PortableTextListItemDefault
-          : TBlockListItem
+        string extends TBlockStyle
+          ? "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal"
+          : TBlockStyle,
+        string extends TBlockListItem ? "bullet" | "number" : TBlockListItem
       >,
       BlockRule
     >
@@ -457,6 +457,12 @@ export type BlockDefinition<
             }
           : unknown)
     >[];
+    marks?: MergeOld<
+      BlockMarksDefinition,
+      {
+        annotations?: TBlockMarkAnnotation[];
+      }
+    >;
     of?: TupleOfLength<TMemberDefinition, 1>;
     styles?: BlockStyleDefinition<
       TBlockStyle &
@@ -624,6 +630,9 @@ type IntrinsicDefinitions<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -636,6 +645,7 @@ type IntrinsicDefinitions<
   block: BlockDefinition<
     TBlockStyle,
     TBlockListItem,
+    TBlockMarkAnnotation,
     TMemberDefinition,
     TRequired
   >;
@@ -658,7 +668,7 @@ type IntrinsicDefinitions<
 };
 
 export type IntrinsicTypeName = Simplify<
-  keyof IntrinsicDefinitions<any, any, any, any, any, any, any, any, any>
+  keyof IntrinsicDefinitions<any, any, any, any, any, any, any, any, any, any>
 >;
 
 declare const aliasedType: unique symbol;
@@ -675,6 +685,9 @@ export type TypeAliasDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -692,6 +705,7 @@ export type TypeAliasDefinition<
           TReferenced,
           TBlockStyle,
           TBlockListItem,
+          TBlockMarkAnnotation,
           THotspot,
           TFieldDefinition,
           TMemberDefinition,
@@ -713,6 +727,9 @@ export type ArrayMemberDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -736,6 +753,7 @@ export type ArrayMemberDefinition<
               TReferenced,
               TBlockStyle,
               TBlockListItem,
+              TBlockMarkAnnotation,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -748,6 +766,7 @@ export type ArrayMemberDefinition<
                     TReferenced,
                     TBlockStyle,
                     TBlockListItem,
+                    TBlockMarkAnnotation,
                     THotspot,
                     TFieldDefinition,
                     TMemberDefinition,
@@ -777,6 +796,7 @@ export type ArrayMemberDefinition<
                   TReferenced,
                   TBlockStyle,
                   TBlockListItem,
+                  TBlockMarkAnnotation,
                   THotspot,
                   TFieldDefinition,
                   TMemberDefinition,
@@ -797,6 +817,7 @@ export type ArrayMemberDefinition<
             TReferenced,
             TBlockStyle,
             TBlockListItem,
+            TBlockMarkAnnotation,
             THotspot,
             TFieldDefinition,
             TMemberDefinition,
@@ -838,6 +859,9 @@ export const makeDefineArrayMember =
     const TReferenced extends string,
     const TBlockStyle extends string,
     const TBlockListItem extends string,
+    const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+      name?: string;
+    },
     const THotspot extends boolean,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
       name: string;
@@ -857,6 +881,7 @@ export const makeDefineArrayMember =
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       TFieldDefinition,
       TMemberDefinition,
@@ -881,6 +906,9 @@ export type FieldDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -905,6 +933,7 @@ export type FieldDefinition<
               TReferenced,
               TBlockStyle,
               TBlockListItem,
+              TBlockMarkAnnotation,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -923,6 +952,7 @@ export type FieldDefinition<
         TReferenced,
         TBlockStyle,
         TBlockListItem,
+        TBlockMarkAnnotation,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -944,6 +974,9 @@ export const defineField = <
   const TReferenced extends string,
   const TBlockStyle extends string,
   const TBlockListItem extends string,
+  const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -964,6 +997,7 @@ export const defineField = <
     TReferenced,
     TBlockStyle,
     TBlockListItem,
+    TBlockMarkAnnotation,
     THotspot,
     TFieldDefinition,
     TMemberDefinition,
@@ -982,6 +1016,9 @@ export type TypeDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -1000,6 +1037,7 @@ export type TypeDefinition<
               TReferenced,
               TBlockStyle,
               TBlockListItem,
+              TBlockMarkAnnotation,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -1018,6 +1056,7 @@ export type TypeDefinition<
         TReferenced,
         TBlockStyle,
         TBlockListItem,
+        TBlockMarkAnnotation,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -1038,6 +1077,9 @@ export const defineType = <
   const TReferenced extends string,
   const TBlockStyle extends string,
   const TBlockListItem extends string,
+  const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -1057,6 +1099,7 @@ export const defineType = <
     TReferenced,
     TBlockStyle,
     TBlockListItem,
+    TBlockMarkAnnotation,
     THotspot,
     TFieldDefinition,
     TMemberDefinition
@@ -1070,6 +1113,7 @@ export const defineType = <
 
 export type ConfigBase<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1116,6 +1160,7 @@ export type PluginOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1124,6 +1169,7 @@ export type PluginOptions<
 
 export const definePlugin = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1161,6 +1207,7 @@ type WorkspaceOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1171,6 +1218,7 @@ type WorkspaceOptions<
 
 export type Config<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1197,6 +1245,7 @@ export type Config<
 
 export const defineConfig = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1261,6 +1310,7 @@ export type InferSchemaValues<
         AliasValue<TName>,
         InferSchemaValues<TPluginOptions> & {
           [TDefinition in TypeDefinition<
+            any,
             any,
             any,
             any,
@@ -1343,6 +1393,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1354,6 +1405,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 TName,
                 NonNullable<TAlias>,
                 TStrict,
+                any,
                 any,
                 any,
                 any,
@@ -1380,6 +1432,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1397,6 +1450,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
     infer TName extends string,
     infer TAlias extends IntrinsicTypeName,
     infer TStrict extends StrictDefinition,
+    any,
     any,
     any,
     any,
@@ -1429,6 +1483,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         any,
         any,
         any,
+        any,
         any
       >
     ? ReturnType<
@@ -1446,6 +1501,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         infer TName extends string,
         infer TAlias extends IntrinsicTypeName,
         infer TStrict extends StrictDefinition,
+        any,
         any,
         any,
         any,

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -417,9 +417,7 @@ export type BlockDefinition<
   DefinitionBase<
     TRequired,
     PortableTextBlock<
-      DefinitionBase<any, any, any> & {
-        name?: string;
-      } extends TBlockMarkAnnotation
+      TBlockMarkAnnotation extends never
         ? never
         : InferRawValue<TBlockMarkAnnotation> & { _key: string },
       | PortableTextSpan
@@ -433,9 +431,7 @@ export type BlockDefinition<
     >,
     RewriteValue<
       PortableTextBlock<
-        DefinitionBase<any, any, any> & {
-          name?: string;
-        } extends TBlockMarkAnnotation
+        TBlockMarkAnnotation extends never
           ? never
           : InferRawValue<TBlockMarkAnnotation> & { _key: string },
         | PortableTextSpan
@@ -860,10 +856,10 @@ export const makeDefineArrayMember =
     const TReferenced extends string,
     const TBlockStyle extends string,
     const TBlockListItem extends string,
-    const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
       name?: string;
-    },
-    const THotspot extends boolean,
+    } = never,
+    const THotspot extends boolean = boolean,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
       name: string;
       [required]?: boolean;
@@ -975,10 +971,10 @@ export const defineField = <
   const TReferenced extends string,
   const TBlockStyle extends string,
   const TBlockListItem extends string,
-  const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
     name?: string;
-  },
-  const THotspot extends boolean,
+  } = never,
+  const THotspot extends boolean = boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -1078,10 +1074,10 @@ export const defineType = <
   const TReferenced extends string,
   const TBlockStyle extends string,
   const TBlockListItem extends string,
-  const TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
     name?: string;
-  },
-  const THotspot extends boolean,
+  } = never,
+  const THotspot extends boolean = boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -538,7 +538,7 @@ export type ImageValue<
 >;
 
 export type ImageDefinition<
-  TOptionsHelper,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -548,15 +548,9 @@ export type ImageDefinition<
   ImageDefinitionNative,
   DefinitionBase<
     TRequired,
-    ImageValue<
-      TOptionsHelper extends boolean ? TOptionsHelper : false,
-      TFieldDefinition
-    >,
+    ImageValue<boolean extends THotspot ? false : THotspot, TFieldDefinition>,
     RewriteValue<
-      ImageValue<
-        TOptionsHelper extends boolean ? TOptionsHelper : false,
-        TFieldDefinition
-      >,
+      ImageValue<boolean extends THotspot ? false : THotspot, TFieldDefinition>,
       ImageRule
     >
   > & {
@@ -564,17 +558,17 @@ export type ImageDefinition<
     options?: MergeOld<
       ImageOptions,
       {
-        hotspot?: TOptionsHelper;
+        hotspot?: THotspot;
       }
     >;
   }
 >;
 
 type IntrinsicDefinitions<
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -592,7 +586,7 @@ type IntrinsicDefinitions<
   email: EmailDefinition<TRequired>;
   file: FileDefinition<TFieldDefinition, TRequired>;
   geopoint: GeopointDefinition<TRequired>;
-  image: ImageDefinition<TOptionsHelper, TFieldDefinition, TRequired>;
+  image: ImageDefinition<THotspot, TFieldDefinition, TRequired>;
   number: NumberDefinition<TNumberValue, TRequired>;
   object: ObjectDefinition<TFieldDefinition, TRequired>;
   reference: ReferenceDefinition<TReferenced, TRequired>;
@@ -615,10 +609,10 @@ type AliasValue<TType extends string> = {
 export type TypeAliasDefinition<
   TType extends string,
   TAlias extends IntrinsicTypeName,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -630,10 +624,10 @@ export type TypeAliasDefinition<
   DefinitionBase<TRequired, AliasValue<TType>, any> & {
     options?: TAlias extends IntrinsicTypeName
       ? IntrinsicDefinitions<
-          TOptionsHelper,
           TNumberValue,
           TStringValue,
           TReferenced,
+          THotspot,
           TFieldDefinition,
           TMemberDefinition,
           TRequired
@@ -649,10 +643,10 @@ export type ArrayMemberDefinition<
   TName extends string,
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -670,20 +664,20 @@ export type ArrayMemberDefinition<
         {
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
-              TOptionsHelper,
               TNumberValue,
               TStringValue,
               TReferenced,
+              THotspot,
               TFieldDefinition,
               TMemberDefinition,
               any
             >[type] extends DefinitionBase<any, infer Value, infer Rule>
               ? MergeOld<
                   IntrinsicDefinitions<
-                    TOptionsHelper,
                     TNumberValue,
                     TStringValue,
                     TReferenced,
+                    THotspot,
                     TFieldDefinition,
                     TMemberDefinition,
                     any
@@ -707,10 +701,10 @@ export type ArrayMemberDefinition<
                   >
                 >
               : IntrinsicDefinitions<
-                  TOptionsHelper,
                   TNumberValue,
                   TStringValue,
                   TReferenced,
+                  THotspot,
                   TFieldDefinition,
                   TMemberDefinition,
                   any
@@ -725,10 +719,10 @@ export type ArrayMemberDefinition<
           TypeAliasDefinition<
             TType,
             TAlias,
-            TOptionsHelper,
             TNumberValue,
             TStringValue,
             TReferenced,
+            THotspot,
             TFieldDefinition,
             TMemberDefinition,
             any
@@ -766,8 +760,8 @@ export const makeDefineArrayMember =
     TStrict extends StrictDefinition,
     const TNumberValue extends number,
     const TStringValue extends string,
-    TReferenced extends string,
-    const TOptionsHelper,
+    const TReferenced extends string,
+    const THotspot extends boolean,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
       name: string;
       [required]?: boolean;
@@ -781,10 +775,10 @@ export const makeDefineArrayMember =
       TName,
       TAlias,
       TStrict,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       TFieldDefinition,
       TMemberDefinition,
       AllowArrays
@@ -803,10 +797,10 @@ export type FieldDefinition<
   TName extends string,
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -825,10 +819,10 @@ export type FieldDefinition<
         {
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
-              TOptionsHelper,
               TNumberValue,
               TStringValue,
               TReferenced,
+              THotspot,
               TFieldDefinition,
               TMemberDefinition,
               TRequired
@@ -841,10 +835,10 @@ export type FieldDefinition<
     : TypeAliasDefinition<
         TType,
         TAlias,
-        TOptionsHelper,
         TNumberValue,
         TStringValue,
         TReferenced,
+        THotspot,
         TFieldDefinition,
         TMemberDefinition,
         TRequired
@@ -860,10 +854,10 @@ export const defineField = <
   TName extends string,
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
-  const TOptionsHelper,
   const TNumberValue extends number,
   const TStringValue extends string,
-  TReferenced extends string,
+  const TReferenced extends string,
+  const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -878,10 +872,10 @@ export const defineField = <
     TName,
     TAlias,
     TStrict,
-    TOptionsHelper,
     TNumberValue,
     TStringValue,
     TReferenced,
+    THotspot,
     TFieldDefinition,
     TMemberDefinition,
     TRequired
@@ -894,10 +888,10 @@ export type TypeDefinition<
   TName extends string,
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -910,10 +904,10 @@ export type TypeDefinition<
         {
           [type in IntrinsicTypeName]: Omit<
             IntrinsicDefinitions<
-              TOptionsHelper,
               TNumberValue,
               TStringValue,
               TReferenced,
+              THotspot,
               TFieldDefinition,
               TMemberDefinition,
               any
@@ -926,10 +920,10 @@ export type TypeDefinition<
     : TypeAliasDefinition<
         TType,
         TAlias,
-        TOptionsHelper,
         TNumberValue,
         TStringValue,
         TReferenced,
+        THotspot,
         TFieldDefinition,
         TMemberDefinition,
         any
@@ -944,10 +938,10 @@ export const defineType = <
   TName extends string,
   TAlias extends IntrinsicTypeName,
   TStrict extends StrictDefinition,
-  const TOptionsHelper,
   const TNumberValue extends number,
   const TStringValue extends string,
-  TReferenced extends string,
+  const TReferenced extends string,
+  const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
     [required]?: boolean;
@@ -961,10 +955,10 @@ export const defineType = <
     TName,
     TAlias,
     TStrict,
-    TOptionsHelper,
     TNumberValue,
     TStringValue,
     TReferenced,
+    THotspot,
     TFieldDefinition,
     TMemberDefinition
   >,
@@ -1039,16 +1033,14 @@ export const definePlugin = <
     any
   >,
   TPluginOptions extends PluginOptions<any, any>,
-  TOptionsHelper = void
+  TOptions = void
 >(
   arg:
     | PluginOptions<TTypeDefinition, TPluginOptions>
-    | ((
-        options: TOptionsHelper
-      ) => PluginOptions<TTypeDefinition, TPluginOptions>)
+    | ((options: TOptions) => PluginOptions<TTypeDefinition, TPluginOptions>)
 ) =>
   definePluginNative(arg as any) as (
-    options: TOptionsHelper
+    options: TOptions
   ) => PluginOptions<TTypeDefinition, TPluginOptions>;
 
 type WorkspaceOptions<

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -15,6 +15,7 @@ import type {
   ArrayRule,
   BlockDefinition as BlockDefinitionNative,
   BlockRule,
+  BlockStyleDefinition as BlockStyleDefinitionNative,
   BooleanDefinition as BooleanDefinitionNative,
   BooleanRule,
   ComposableOption,
@@ -365,6 +366,16 @@ export type ArrayDefinition<
   }
 >;
 
+type PortableTextBlockStyleDefault =
+  | "blockquote"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "normal";
+
 export type PortableTextMarkDefinition =
   OmitIndexSignature<PortableTextMarkDefinitionNative>;
 
@@ -381,12 +392,20 @@ export type PortableTextBlock<
   level?: number;
   listItem?: L;
   markDefs?: M[];
-  style?: S;
+  style: S;
 };
 // TODO PortableTextBlock is too complex for some reason https://github.com/saiichihashimoto/sanity-typed/issues/415
 // > = Omit<PortableTextBlockNative<M, C, S, L> & { _type: "block" }, "_key">;
 
+export type BlockStyleDefinition<Value extends string> = MergeOld<
+  BlockStyleDefinitionNative,
+  {
+    value: Value;
+  }
+>;
+
 export type BlockDefinition<
+  TBlockStyle extends string,
   TMemberDefinition extends DefinitionBase<any, any, any> & { name?: string },
   TRequired extends boolean
 > = MergeOld<
@@ -398,7 +417,8 @@ export type BlockDefinition<
       | PortableTextSpan
       | (TMemberDefinition extends never
           ? never
-          : InferRawValue<TMemberDefinition> & { _key: string })
+          : InferRawValue<TMemberDefinition> & { _key: string }),
+      string extends TBlockStyle ? PortableTextBlockStyleDefault : TBlockStyle
     >,
     RewriteValue<
       PortableTextBlock<
@@ -406,12 +426,21 @@ export type BlockDefinition<
         | PortableTextSpan
         | (TMemberDefinition extends never
             ? never
-            : InferRawValue<TMemberDefinition> & { _key: string })
+            : InferRawValue<TMemberDefinition> & { _key: string }),
+        string extends TBlockStyle ? PortableTextBlockStyleDefault : TBlockStyle
       >,
       BlockRule
     >
   > & {
     of?: TupleOfLength<TMemberDefinition, 1>;
+    styles?: BlockStyleDefinition<
+      TBlockStyle &
+        (IsStringLiteral<TBlockStyle> extends false
+          ? {
+              [README]: "⛔️ Unfortunately, this needs an `as const` for correct types. ⛔️";
+            }
+          : unknown)
+    >[];
   }
 >;
 
@@ -568,6 +597,7 @@ type IntrinsicDefinitions<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -577,7 +607,7 @@ type IntrinsicDefinitions<
   TRequired extends boolean
 > = {
   array: ArrayDefinition<TMemberDefinition, TRequired>;
-  block: BlockDefinition<TMemberDefinition, TRequired>;
+  block: BlockDefinition<TBlockStyle, TMemberDefinition, TRequired>;
   boolean: BooleanDefinition<TRequired>;
   crossDatasetReference: CrossDatasetReferenceDefinition<TRequired>;
   date: DateDefinition<TRequired>;
@@ -597,7 +627,7 @@ type IntrinsicDefinitions<
 };
 
 export type IntrinsicTypeName = Simplify<
-  keyof IntrinsicDefinitions<any, any, any, any, any, any, any>
+  keyof IntrinsicDefinitions<any, any, any, any, any, any, any, any>
 >;
 
 declare const aliasedType: unique symbol;
@@ -612,6 +642,7 @@ export type TypeAliasDefinition<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -627,6 +658,7 @@ export type TypeAliasDefinition<
           TNumberValue,
           TStringValue,
           TReferenced,
+          TBlockStyle,
           THotspot,
           TFieldDefinition,
           TMemberDefinition,
@@ -646,6 +678,7 @@ export type ArrayMemberDefinition<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -667,6 +700,7 @@ export type ArrayMemberDefinition<
               TNumberValue,
               TStringValue,
               TReferenced,
+              TBlockStyle,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -677,6 +711,7 @@ export type ArrayMemberDefinition<
                     TNumberValue,
                     TStringValue,
                     TReferenced,
+                    TBlockStyle,
                     THotspot,
                     TFieldDefinition,
                     TMemberDefinition,
@@ -704,6 +739,7 @@ export type ArrayMemberDefinition<
                   TNumberValue,
                   TStringValue,
                   TReferenced,
+                  TBlockStyle,
                   THotspot,
                   TFieldDefinition,
                   TMemberDefinition,
@@ -722,6 +758,7 @@ export type ArrayMemberDefinition<
             TNumberValue,
             TStringValue,
             TReferenced,
+            TBlockStyle,
             THotspot,
             TFieldDefinition,
             TMemberDefinition,
@@ -761,6 +798,7 @@ export const makeDefineArrayMember =
     const TNumberValue extends number,
     const TStringValue extends string,
     const TReferenced extends string,
+    const TBlockStyle extends string,
     const THotspot extends boolean,
     TFieldDefinition extends DefinitionBase<any, any, any> & {
       name: string;
@@ -778,6 +816,7 @@ export const makeDefineArrayMember =
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       TFieldDefinition,
       TMemberDefinition,
@@ -800,6 +839,7 @@ export type FieldDefinition<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -822,6 +862,7 @@ export type FieldDefinition<
               TNumberValue,
               TStringValue,
               TReferenced,
+              TBlockStyle,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -838,6 +879,7 @@ export type FieldDefinition<
         TNumberValue,
         TStringValue,
         TReferenced,
+        TBlockStyle,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -857,6 +899,7 @@ export const defineField = <
   const TNumberValue extends number,
   const TStringValue extends string,
   const TReferenced extends string,
+  const TBlockStyle extends string,
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -875,6 +918,7 @@ export const defineField = <
     TNumberValue,
     TStringValue,
     TReferenced,
+    TBlockStyle,
     THotspot,
     TFieldDefinition,
     TMemberDefinition,
@@ -891,6 +935,7 @@ export type TypeDefinition<
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -907,6 +952,7 @@ export type TypeDefinition<
               TNumberValue,
               TStringValue,
               TReferenced,
+              TBlockStyle,
               THotspot,
               TFieldDefinition,
               TMemberDefinition,
@@ -923,6 +969,7 @@ export type TypeDefinition<
         TNumberValue,
         TStringValue,
         TReferenced,
+        TBlockStyle,
         THotspot,
         TFieldDefinition,
         TMemberDefinition,
@@ -941,6 +988,7 @@ export const defineType = <
   const TNumberValue extends number,
   const TStringValue extends string,
   const TReferenced extends string,
+  const TBlockStyle extends string,
   const THotspot extends boolean,
   TFieldDefinition extends DefinitionBase<any, any, any> & {
     name: string;
@@ -958,6 +1006,7 @@ export const defineType = <
     TNumberValue,
     TStringValue,
     TReferenced,
+    TBlockStyle,
     THotspot,
     TFieldDefinition,
     TMemberDefinition
@@ -971,6 +1020,7 @@ export const defineType = <
 
 export type ConfigBase<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1013,6 +1063,7 @@ export type PluginOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1021,6 +1072,7 @@ export type PluginOptions<
 
 export const definePlugin = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1054,6 +1106,7 @@ type WorkspaceOptions<
     any,
     any,
     any,
+    any,
     any
   >,
   TPluginOptions extends PluginOptions<any, any>
@@ -1064,6 +1117,7 @@ type WorkspaceOptions<
 
 export type Config<
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1088,6 +1142,7 @@ export type Config<
 
 export const defineConfig = <
   TTypeDefinition extends TypeDefinition<
+    any,
     any,
     any,
     any,
@@ -1150,6 +1205,7 @@ export type InferSchemaValues<
         AliasValue<TName>,
         InferSchemaValues<TPluginOptions> & {
           [TDefinition in TypeDefinition<
+            any,
             any,
             any,
             any,
@@ -1228,6 +1284,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1239,6 +1296,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 TName,
                 NonNullable<TAlias>,
                 TStrict,
+                any,
                 any,
                 any,
                 any,
@@ -1261,6 +1319,7 @@ export const castToTyped = <Untyped>(untyped: Untyped) =>
                 any,
                 any,
                 any,
+                any,
                 any
               >
             : never)
@@ -1278,6 +1337,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
     infer TName extends string,
     infer TAlias extends IntrinsicTypeName,
     infer TStrict extends StrictDefinition,
+    any,
     any,
     any,
     any,
@@ -1306,6 +1366,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         any,
         any,
         any,
+        any,
         any
       >
     ? ReturnType<
@@ -1323,6 +1384,7 @@ export const castFromTyped = <Typed>(typed: Typed) =>
         infer TName extends string,
         infer TAlias extends IntrinsicTypeName,
         infer TStrict extends StrictDefinition,
+        any,
         any,
         any,
         any,

--- a/packages/types/src/specific-issues.test.ts
+++ b/packages/types/src/specific-issues.test.ts
@@ -149,12 +149,20 @@ describe("specific issues", () => {
           text: string;
         }[];
         level?: number;
-        listItem?: string;
-        markDefs?: {
+        listItem?: "bullet" | "number";
+        markDefs: {
           _key: string;
           _type: string;
         }[];
-        style?: string;
+        style:
+          | "blockquote"
+          | "h1"
+          | "h2"
+          | "h3"
+          | "h4"
+          | "h5"
+          | "h6"
+          | "normal";
       }[];
     }>();
   });

--- a/packages/types/src/specific-issues.test.ts
+++ b/packages/types/src/specific-issues.test.ts
@@ -145,7 +145,7 @@ describe("specific issues", () => {
         children: {
           _key: string;
           _type: "span";
-          marks?: string[];
+          marks: string[];
           text: string;
         }[];
         level?: number;

--- a/packages/types/src/specific-issues.test.ts
+++ b/packages/types/src/specific-issues.test.ts
@@ -150,10 +150,7 @@ describe("specific issues", () => {
         }[];
         level?: number;
         listItem?: "bullet" | "number";
-        markDefs: {
-          _key: string;
-          _type: string;
-        }[];
+        markDefs: never[];
         style:
           | "blockquote"
           | "h1"

--- a/packages/zod/src/block.test.ts
+++ b/packages/zod/src/block.test.ts
@@ -13,7 +13,7 @@ import { sanityConfigToZodsTyped } from "./internal";
 
 const fields: Omit<PortableTextBlock, "_type" | "children"> = {
   level: 1,
-  listItem: "listItem",
+  listItem: "bullet",
   markDefs: [{ _key: "key", _type: "type" }],
   style: "normal",
 };
@@ -189,7 +189,7 @@ describe("block", () => {
       >();
     });
 
-    it("builds parser for styles", async () => {
+    it("builds parser for style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -233,7 +233,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts lists", async () => {
+    it("builds parser for listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -246,8 +246,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   lists: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -262,6 +262,7 @@ describe("block", () => {
           ...fields,
           _key: "key",
           _type: "block",
+          listItem: "foo",
           children: [
             { _key: "key", _type: "span", marks: ["mark"], text: "text" },
           ],
@@ -524,7 +525,7 @@ describe("block", () => {
       >();
     });
 
-    it("builds parser for styles", async () => {
+    it("builds parser for style", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -560,7 +561,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts lists", async () => {
+    it("builds parser for listItem", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -570,8 +571,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               lists: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],
@@ -582,6 +583,7 @@ describe("block", () => {
       const unparsed = {
         ...fields,
         _type: "foo",
+        listItem: "foo",
         children: [
           { _key: "key", _type: "span", marks: ["mark"], text: "text" },
         ],

--- a/packages/zod/src/block.test.ts
+++ b/packages/zod/src/block.test.ts
@@ -376,10 +376,12 @@ describe("block", () => {
         },
       ];
 
+      // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
       const parsed = zods.foo.parse(unparsed);
 
       expect(parsed).toStrictEqual(unparsed);
       expectType<(typeof parsed)[number]>().toStrictEqual<
+        // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
         InferSchemaValues<typeof config>["foo"][number]
       >();
     });
@@ -453,12 +455,10 @@ describe("block", () => {
         },
       ];
 
-      // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
       const parsed = zods.bar.parse(unparsed);
 
       expect(parsed).toStrictEqual(unparsed);
       expectType<(typeof parsed)[number]["_type"]>().toStrictEqual<
-        // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
         InferSchemaValues<typeof config>["bar"][number]["_type"]
       >();
     });

--- a/packages/zod/src/block.test.ts
+++ b/packages/zod/src/block.test.ts
@@ -15,7 +15,7 @@ const fields: Omit<PortableTextBlock, "_type" | "children"> = {
   level: 1,
   listItem: "listItem",
   markDefs: [{ _key: "key", _type: "type" }],
-  style: "style",
+  style: "normal",
 };
 
 describe("block", () => {
@@ -189,7 +189,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts styles", async () => {
+    it("builds parser for styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -202,8 +202,8 @@ describe("block", () => {
                 defineArrayMember({
                   type: "block",
                   styles: [
-                    { title: "Foo", value: "foo" },
-                    { title: "Bar", value: "bar" },
+                    { title: "Foo", value: "foo" as const },
+                    { title: "Bar", value: "bar" as const },
                   ],
                 }),
               ],
@@ -218,6 +218,7 @@ describe("block", () => {
           ...fields,
           _key: "key",
           _type: "block",
+          style: "foo",
           children: [
             { _key: "key", _type: "span", marks: ["mark"], text: "text" },
           ],
@@ -523,7 +524,7 @@ describe("block", () => {
       >();
     });
 
-    it("accepts styles", async () => {
+    it("builds parser for styles", async () => {
       const config = defineConfig({
         dataset: "dataset",
         projectId: "projectId",
@@ -533,8 +534,8 @@ describe("block", () => {
               name: "foo",
               type: "block",
               styles: [
-                { title: "Foo", value: "foo" },
-                { title: "Bar", value: "bar" },
+                { title: "Foo", value: "foo" as const },
+                { title: "Bar", value: "bar" as const },
               ],
             }),
           ],
@@ -545,6 +546,7 @@ describe("block", () => {
       const unparsed = {
         ...fields,
         _type: "foo",
+        style: "foo",
         children: [
           { _key: "key", _type: "span", marks: ["mark"], text: "text" },
         ],

--- a/packages/zod/src/block.test.ts
+++ b/packages/zod/src/block.test.ts
@@ -188,6 +188,193 @@ describe("block", () => {
         InferSchemaValues<typeof config>["foo"][number]["children"]
       >();
     });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  styles: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = [
+        {
+          ...fields,
+          _key: "key",
+          _type: "block",
+          children: [
+            { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+          ],
+        },
+      ];
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<(typeof parsed)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  lists: [
+                    { title: "Foo", value: "foo" },
+                    { title: "Bar", value: "bar" },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = [
+        {
+          ...fields,
+          _key: "key",
+          _type: "block",
+          children: [
+            { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+          ],
+        },
+      ];
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<(typeof parsed)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    decorators: [
+                      { title: "Foo", value: "foo" },
+                      { title: "Bar", value: "bar" },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = [
+        {
+          ...fields,
+          _key: "key",
+          _type: "block",
+          children: [
+            { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+          ],
+        },
+      ];
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<(typeof parsed)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "array",
+              of: [
+                defineArrayMember({
+                  type: "block",
+                  marks: {
+                    annotations: [
+                      {
+                        name: "internalLink",
+                        type: "object",
+                        title: "Internal link",
+                        fields: [
+                          {
+                            name: "reference",
+                            type: "reference",
+                            title: "Reference",
+                            to: [{ type: "post" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                }),
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = [
+        {
+          ...fields,
+          _key: "key",
+          _type: "block",
+          children: [
+            { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+          ],
+        },
+      ];
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<(typeof parsed)[number]>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"][number]
+      >();
+    });
   });
 
   describe("defineType", () => {
@@ -333,6 +520,161 @@ describe("block", () => {
       expect(parsed).toStrictEqual(unparsed);
       expectType<(typeof parsed)["children"]>().toStrictEqual<
         InferSchemaValues<typeof config>["foo"]["children"]
+      >();
+    });
+
+    it("accepts styles", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              styles: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = {
+        ...fields,
+        _type: "foo",
+        children: [
+          { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+        ],
+      };
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<typeof parsed>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts lists", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              lists: [
+                { title: "Foo", value: "foo" },
+                { title: "Bar", value: "bar" },
+              ],
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = {
+        ...fields,
+        _type: "foo",
+        children: [
+          { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+        ],
+      };
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<typeof parsed>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts decorators", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                decorators: [
+                  { title: "Foo", value: "foo" },
+                  { title: "Bar", value: "bar" },
+                ],
+              },
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = {
+        ...fields,
+        _type: "foo",
+        children: [
+          { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+        ],
+      };
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<typeof parsed>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
+      >();
+    });
+
+    it("accepts annotations", async () => {
+      const config = defineConfig({
+        dataset: "dataset",
+        projectId: "projectId",
+        schema: {
+          types: [
+            defineType({
+              name: "foo",
+              type: "block",
+              marks: {
+                annotations: [
+                  {
+                    name: "internalLink",
+                    type: "object",
+                    title: "Internal link",
+                    fields: [
+                      {
+                        name: "reference",
+                        type: "reference",
+                        title: "Reference",
+                        to: [{ type: "post" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            }),
+          ],
+        },
+      });
+      const zods = sanityConfigToZodsTyped(config);
+
+      const unparsed = {
+        ...fields,
+        _type: "foo",
+        children: [
+          { _key: "key", _type: "span", marks: ["mark"], text: "text" },
+        ],
+      };
+
+      const parsed = zods.foo.parse(unparsed);
+
+      expect(parsed).toStrictEqual(unparsed);
+      expectType<typeof parsed>().toStrictEqual<
+        InferSchemaValues<typeof config>["foo"]
       >();
     });
   });

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { traverseValidation } from "@sanity-typed/traverse-validation";
 import type {
+  BlockListDefinition,
   BlockStyleDefinition,
   InferSchemaValues,
 } from "@sanity-typed/types";
@@ -26,6 +27,7 @@ type SchemaTypeDefinition<
   TStringValue extends string,
   TReferenced extends string,
   TBlockStyle extends string,
+  TBlockListItem extends string,
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -37,6 +39,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any,
@@ -51,6 +54,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any,
@@ -65,6 +69,7 @@ type SchemaTypeDefinition<
       TStringValue,
       TReferenced,
       TBlockStyle,
+      TBlockListItem,
       THotspot,
       any,
       any
@@ -117,7 +122,7 @@ const toZodType = <Output, Input>(
 ) => zod as z.ZodType<Output, z.ZodTypeDef, Input>;
 
 const dateZod = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -145,7 +150,15 @@ const dateZod = <
 };
 
 const datetimeZod = <
-  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "datetime",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -172,7 +185,15 @@ const datetimeZod = <
 };
 
 const numberZod = <
-  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "number",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -181,6 +202,7 @@ const numberZod = <
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
     infer TNumberValue,
+    any,
     any,
     any,
     any,
@@ -235,7 +257,15 @@ const numberZod = <
 };
 
 const referenceZod = <
-  TSchemaType extends SchemaTypeDefinition<"reference", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "reference",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >() =>
   z.object({
     [referenced]:
@@ -245,6 +275,7 @@ const referenceZod = <
           any,
           any,
           infer TReferenced,
+          any,
           any,
           any
         >
@@ -271,6 +302,7 @@ const referenceZod = <
 const stringAndTextZod = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -352,7 +384,15 @@ const stringAndTextZod = <
 };
 
 const stringZod = <
-  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "string",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -360,6 +400,7 @@ const stringZod = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any,
     any
@@ -390,7 +431,7 @@ const stringZod = <
 };
 
 const textZod = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => stringAndTextZod(schemaType);
@@ -398,7 +439,7 @@ const textZod = <
 const DUMMY_ORIGIN = "http://sanity";
 
 const urlZod = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -636,10 +677,12 @@ type MembersZods<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -666,6 +709,7 @@ type MembersZods<
 
 const membersZods = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -738,10 +782,19 @@ const sanityDeepEquals = (a: unknown, b: unknown): boolean =>
 type MaybeZodEffects<T extends z.ZodTypeAny> = T | z.ZodEffects<T>;
 
 type ArrayZod<
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "array",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -766,7 +819,15 @@ type ArrayZod<
   : never;
 
 const arrayZod = <
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "array",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schemaType: TSchemaType,
@@ -822,21 +883,28 @@ type SpanZod = typeof spanZod;
 
 const blockFieldsZods = {
   _type: z.literal("block"),
+  // TODO Only have level if we also have listItem
   level: z.optional(z.number()),
-  listItem: z.optional(z.string()),
-  markDefs: z.optional(
-    z.array(
-      z.object({
-        _key: z.string(),
-        _type: z.string(),
-      })
-    )
+  markDefs: z.array(
+    z.object({
+      _key: z.string(),
+      _type: z.string(),
+    })
   ),
 };
 
 const blockCustomFields = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >({
+  lists,
   styles,
 }: TSchemaType) => {
   type TBlockStyle = TSchemaType extends SchemaTypeDefinition<
@@ -845,12 +913,38 @@ const blockCustomFields = <
     any,
     any,
     infer TBlockStyle,
+    any,
     any
   >
     ? TBlockStyle
     : never;
 
+  type TBlockListItem = TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    infer TBlockListItem,
+    any
+  >
+    ? TBlockListItem
+    : never;
+
   return {
+    // TODO Only allow level & listItem together, never separate
+    listItem: typedTernary(
+      !lists?.length as Negate<IsStringLiteral<TBlockListItem>>,
+      () => z.optional(z.union([z.literal("bullet"), z.literal("number")])),
+      () =>
+        z.optional(
+          zodUnion(
+            (lists! as BlockListDefinition<TBlockListItem>[]).map(({ value }) =>
+              z.literal(value)
+            )
+          )
+        )
+    ),
     style: typedTernary(
       !styles?.length as Negate<IsStringLiteral<TBlockStyle>>,
       () =>
@@ -875,7 +969,15 @@ const blockCustomFields = <
 };
 
 type BlockZod<
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   ReturnType<typeof blockCustomFields<TSchemaType>> &
@@ -883,6 +985,7 @@ type BlockZod<
       children: z.ZodArray<
         TSchemaType extends {
           of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+            any,
             any,
             any,
             any,
@@ -904,7 +1007,15 @@ type BlockZod<
 >;
 
 const blockZod = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schemaType: TSchemaType,
@@ -931,6 +1042,7 @@ const blockZod = <
                 any,
                 any,
                 any,
+                any,
                 any
               >[],
               getZods
@@ -942,6 +1054,7 @@ const blockZod = <
 type FieldsZods<
   TSchemaType extends SchemaTypeDefinition<
     "document" | "file" | "image" | "object",
+    any,
     any,
     any,
     any,
@@ -962,6 +1075,7 @@ type FieldsZods<
     any,
     any,
     any,
+    any,
     any
   >)[];
 }
@@ -969,6 +1083,7 @@ type FieldsZods<
       [Name in Extract<
         TFieldDefinition,
         FieldDefinition<
+          any,
           any,
           any,
           any,
@@ -1001,6 +1116,7 @@ type FieldsZods<
           any,
           any,
           any,
+          any,
           true
         >
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursive
@@ -1018,6 +1134,7 @@ const fieldsZods = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1028,6 +1145,7 @@ const fieldsZods = <
   Object.fromEntries(
     (
       fields as FieldDefinition<
+        any,
         any,
         any,
         any,
@@ -1059,12 +1177,28 @@ const fieldsZods = <
   ) as FieldsZods<TSchemaType, TAliasedZods>;
 
 type ObjectZod<
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "object",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<FieldsZods<TSchemaType, TAliasedZods>>;
 
 const objectZod = <
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "object",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1081,14 +1215,30 @@ const documentFieldsZods = {
 };
 
 type DocumentZod<
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "document",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   FieldsZods<TSchemaType, TAliasedZods> & typeof documentFieldsZods
 >;
 
 const documentZod = <
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "document",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1124,12 +1274,28 @@ const fileFieldsZods = {
 };
 
 type FileZod<
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "file",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<FieldsZods<TSchemaType, TAliasedZods> & typeof fileFieldsZods>;
 
 const fileZod = <
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "file",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1163,13 +1329,22 @@ const imageHotspotFields = {
 };
 
 type ImageZod<
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "image",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   FieldsZods<TSchemaType, TAliasedZods> &
     typeof imageFieldsZods &
     (TSchemaType extends SchemaTypeDefinition<
       "image",
+      any,
       any,
       any,
       any,
@@ -1183,7 +1358,15 @@ type ImageZod<
 >;
 
 const imageZod = <
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    "image",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1196,7 +1379,7 @@ const imageZod = <
   }) as unknown as ImageZod<TSchemaType, TAliasedZods>;
 
 type AliasZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodLazy<
   TSchemaType["type"] extends keyof TAliasedZods
@@ -1205,7 +1388,7 @@ type AliasZod<
 >;
 
 const aliasZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   { type }: TSchemaType,
@@ -1217,7 +1400,7 @@ const aliasZod = <
   >;
 
 type SchemaTypeToZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType["type"] extends keyof typeof constantZods
   ? (typeof constantZods)[TSchemaType["type"]]
@@ -1226,7 +1409,7 @@ type SchemaTypeToZod<
       typeof dateZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"date", any, any, any, any, any>
+          SchemaTypeDefinition<"date", any, any, any, any, any, any>
         >
       >
     >
@@ -1235,7 +1418,7 @@ type SchemaTypeToZod<
       typeof datetimeZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
         >
       >
     >
@@ -1244,7 +1427,7 @@ type SchemaTypeToZod<
       typeof numberZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"number", any, any, any, any, any>
+          SchemaTypeDefinition<"number", any, any, any, any, any, any>
         >
       >
     >
@@ -1253,7 +1436,7 @@ type SchemaTypeToZod<
       typeof referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any, any>
         >
       >
     >
@@ -1262,7 +1445,7 @@ type SchemaTypeToZod<
       typeof stringZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"string", any, any, any, any, any>
+          SchemaTypeDefinition<"string", any, any, any, any, any, any>
         >
       >
     >
@@ -1271,7 +1454,7 @@ type SchemaTypeToZod<
       typeof textZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"text", any, any, any, any, any>
+          SchemaTypeDefinition<"text", any, any, any, any, any, any>
         >
       >
     >
@@ -1280,7 +1463,7 @@ type SchemaTypeToZod<
       typeof urlZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"url", any, any, any, any, any>
+          SchemaTypeDefinition<"url", any, any, any, any, any, any>
         >
       >
     >
@@ -1289,7 +1472,7 @@ type SchemaTypeToZod<
       typeof arrayZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"array", any, any, any, any, any>
+          SchemaTypeDefinition<"array", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1299,7 +1482,7 @@ type SchemaTypeToZod<
       typeof blockZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"block", any, any, any, any, any>
+          SchemaTypeDefinition<"block", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1309,7 +1492,7 @@ type SchemaTypeToZod<
       typeof objectZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1319,7 +1502,7 @@ type SchemaTypeToZod<
       typeof documentZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1329,7 +1512,7 @@ type SchemaTypeToZod<
       typeof fileZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"file", any, any, any, any, any>
+          SchemaTypeDefinition<"file", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1339,7 +1522,7 @@ type SchemaTypeToZod<
       typeof imageZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"image", any, any, any, any, any>
+          SchemaTypeDefinition<"image", any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1347,7 +1530,7 @@ type SchemaTypeToZod<
   : ReturnType<typeof aliasZod<TSchemaType, TAliasedZods>>;
 
 const schemaTypeToZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1361,56 +1544,56 @@ const schemaTypeToZod = <
     ? dateZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"date", any, any, any, any, any>
+          SchemaTypeDefinition<"date", any, any, any, any, any, any>
         >
       )
     : schema.type === "datetime"
     ? datetimeZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
         >
       )
     : schema.type === "number"
     ? numberZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"number", any, any, any, any, any>
+          SchemaTypeDefinition<"number", any, any, any, any, any, any>
         >
       )
     : schema.type === "reference"
     ? referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any, any>
         >
       >()
     : schema.type === "string"
     ? stringZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"string", any, any, any, any, any>
+          SchemaTypeDefinition<"string", any, any, any, any, any, any>
         >
       )
     : schema.type === "text"
     ? textZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"text", any, any, any, any, any>
+          SchemaTypeDefinition<"text", any, any, any, any, any, any>
         >
       )
     : schema.type === "url"
     ? urlZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"url", any, any, any, any, any>
+          SchemaTypeDefinition<"url", any, any, any, any, any, any>
         >
       )
     : schema.type === "array"
     ? arrayZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"array", any, any, any, any, any>
+          SchemaTypeDefinition<"array", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1418,7 +1601,7 @@ const schemaTypeToZod = <
     ? blockZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"block", any, any, any, any, any>
+          SchemaTypeDefinition<"block", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1426,7 +1609,7 @@ const schemaTypeToZod = <
     ? objectZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1434,7 +1617,7 @@ const schemaTypeToZod = <
     ? documentZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1442,7 +1625,7 @@ const schemaTypeToZod = <
     ? fileZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"file", any, any, any, any, any>
+          SchemaTypeDefinition<"file", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1450,7 +1633,7 @@ const schemaTypeToZod = <
     ? imageZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"image", any, any, any, any, any>
+          SchemaTypeDefinition<"image", any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1494,7 +1677,8 @@ export const sanityConfigToZodsTyped = <
   const pluginsZods = plugins
     .map(
       (plugin) =>
-        // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment,@typescript-eslint/prefer-ts-expect-error -- TODO ts-expect-error fails in build, but is needed in test
+        // @ts-ignore -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
         sanityConfigToZodsTyped(plugin) as SanityConfigZods<TPluginOptions>
     )
     .reduce(
@@ -1535,6 +1719,7 @@ export const sanityDocumentsZod = <const TConfig extends ConfigBase<any, any>>(
 ) => {
   type TTypeDefinition = TConfig extends ConfigBase<
     infer TTypeDefinition extends TypeDefinition<
+      any,
       any,
       any,
       any,

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -1789,6 +1789,7 @@ type SanityConfigZods<TConfig extends MaybeArray<ConfigBase<any, any>>> =
     ConfigBase<infer TTypeDefinition, infer TPluginOptions>
   >
     ? {
+        // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
         [Name in TTypeDefinition["name"]]: AddType<
           Name,
           SchemaTypeToZod<

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -19,20 +19,20 @@ import type { MaybeArray } from "@sanity-typed/utils";
 
 type SchemaTypeDefinition<
   TType extends string,
-  TOptionsHelper,
   TNumberValue extends number,
   TStringValue extends string,
-  TReferenced extends string
+  TReferenced extends string,
+  THotspot extends boolean
 > =
   | ArrayMemberDefinition<
       TType,
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any,
       any
@@ -42,10 +42,10 @@ type SchemaTypeDefinition<
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any,
       any
@@ -55,10 +55,10 @@ type SchemaTypeDefinition<
       any,
       any,
       any,
-      TOptionsHelper,
       TNumberValue,
       TStringValue,
       TReferenced,
+      THotspot,
       any,
       any
     >;
@@ -173,8 +173,8 @@ const numberZod = <
 
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
-    any,
     infer TNumberValue,
+    any,
     any,
     any
   >
@@ -236,8 +236,8 @@ const referenceZod = <
           "reference",
           any,
           any,
-          any,
-          infer TReferenced
+          infer TReferenced,
+          any
         >
           ? TReferenced
           : never
@@ -349,8 +349,8 @@ const stringZod = <
   type TStringValue = TSchemaType extends SchemaTypeDefinition<
     "string",
     any,
-    any,
     infer TStringValue,
+    any,
     any
   >
     ? TStringValue
@@ -1075,17 +1075,17 @@ const imageHotspotFields = {
 };
 
 type ImageZod<
-  TSchemaType extends SchemaTypeDefinition<"image", boolean, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   FieldsZods<TSchemaType, TAliasedZods> &
     typeof imageFieldsZods &
     (TSchemaType extends SchemaTypeDefinition<
       "image",
-      infer THotspot,
       any,
       any,
-      any
+      any,
+      infer THotspot extends boolean
     >
       ? THotspot extends true
         ? typeof imageHotspotFields
@@ -1094,7 +1094,7 @@ type ImageZod<
 >;
 
 const imageZod = <
-  TSchemaType extends SchemaTypeDefinition<"image", boolean, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -4,7 +4,10 @@ import type { IsNumericLiteral, IsStringLiteral } from "type-fest";
 import { z } from "zod";
 
 import { traverseValidation } from "@sanity-typed/traverse-validation";
-import type { InferSchemaValues } from "@sanity-typed/types";
+import type {
+  BlockStyleDefinition,
+  InferSchemaValues,
+} from "@sanity-typed/types";
 import { referenced } from "@sanity-typed/types";
 import type {
   ArrayMemberDefinition,
@@ -15,13 +18,14 @@ import type {
   TypeDefinition,
 } from "@sanity-typed/types/src/internal";
 import { typedTernary } from "@sanity-typed/utils";
-import type { MaybeArray } from "@sanity-typed/utils";
+import type { MaybeArray, Negate } from "@sanity-typed/utils";
 
 type SchemaTypeDefinition<
   TType extends string,
   TNumberValue extends number,
   TStringValue extends string,
   TReferenced extends string,
+  TBlockStyle extends string,
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -32,6 +36,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any,
@@ -45,6 +50,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any,
@@ -58,6 +64,7 @@ type SchemaTypeDefinition<
       TNumberValue,
       TStringValue,
       TReferenced,
+      TBlockStyle,
       THotspot,
       any,
       any
@@ -110,7 +117,7 @@ const toZodType = <Output, Input>(
 ) => zod as z.ZodType<Output, z.ZodTypeDef, Input>;
 
 const dateZod = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -138,7 +145,7 @@ const dateZod = <
 };
 
 const datetimeZod = <
-  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"datetime", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -165,7 +172,7 @@ const datetimeZod = <
 };
 
 const numberZod = <
-  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"number", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -174,6 +181,7 @@ const numberZod = <
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
     infer TNumberValue,
+    any,
     any,
     any,
     any
@@ -227,7 +235,7 @@ const numberZod = <
 };
 
 const referenceZod = <
-  TSchemaType extends SchemaTypeDefinition<"reference", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"reference", any, any, any, any, any>
 >() =>
   z.object({
     [referenced]:
@@ -237,6 +245,7 @@ const referenceZod = <
           any,
           any,
           infer TReferenced,
+          any,
           any
         >
           ? TReferenced
@@ -262,6 +271,7 @@ const referenceZod = <
 const stringAndTextZod = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -342,7 +352,7 @@ const stringAndTextZod = <
 };
 
 const stringZod = <
-  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"string", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -350,6 +360,7 @@ const stringZod = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any
   >
@@ -379,7 +390,7 @@ const stringZod = <
 };
 
 const textZod = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => stringAndTextZod(schemaType);
@@ -387,7 +398,7 @@ const textZod = <
 const DUMMY_ORIGIN = "http://sanity";
 
 const urlZod = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any>
 >(
   schemaType: TSchemaType
 ) => {
@@ -624,10 +635,12 @@ type MembersZods<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -653,6 +666,7 @@ type MembersZods<
 
 const membersZods = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -724,10 +738,11 @@ const sanityDeepEquals = (a: unknown, b: unknown): boolean =>
 type MaybeZodEffects<T extends z.ZodTypeAny> = T | z.ZodEffects<T>;
 
 type ArrayZod<
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -751,7 +766,7 @@ type ArrayZod<
   : never;
 
 const arrayZod = <
-  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"array", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schemaType: TSchemaType,
@@ -809,7 +824,6 @@ const blockFieldsZods = {
   _type: z.literal("block"),
   level: z.optional(z.number()),
   listItem: z.optional(z.string()),
-  style: z.optional(z.string()),
   markDefs: z.optional(
     z.array(
       z.object({
@@ -820,49 +834,93 @@ const blockFieldsZods = {
   ),
 };
 
+const blockCustomFields = <
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>
+>({
+  styles,
+}: TSchemaType) => {
+  type TBlockStyle = TSchemaType extends SchemaTypeDefinition<
+    "block",
+    any,
+    any,
+    any,
+    infer TBlockStyle,
+    any
+  >
+    ? TBlockStyle
+    : never;
+
+  return {
+    style: typedTernary(
+      !styles?.length as Negate<IsStringLiteral<TBlockStyle>>,
+      () =>
+        z.union([
+          z.literal("blockquote"),
+          z.literal("h1"),
+          z.literal("h2"),
+          z.literal("h3"),
+          z.literal("h4"),
+          z.literal("h5"),
+          z.literal("h6"),
+          z.literal("normal"),
+        ]),
+      () =>
+        zodUnion(
+          (styles! as BlockStyleDefinition<TBlockStyle>[]).map(({ value }) =>
+            z.literal(value)
+          )
+        )
+    ),
+  };
+};
+
 type BlockZod<
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
-  typeof blockFieldsZods & {
-    children: z.ZodArray<
-      TSchemaType extends {
-        of?: infer TMemberDefinitions extends ArrayMemberDefinition<
-          any,
-          any,
-          any,
-          any,
-          any,
-          any,
-          any,
-          any,
-          any,
-          any,
-          any
-        >[];
-      }
-        ? MembersZods<TMemberDefinitions, TAliasedZods>[number] | SpanZod
-        : SpanZod
-    >;
-  }
+  ReturnType<typeof blockCustomFields<TSchemaType>> &
+    typeof blockFieldsZods & {
+      children: z.ZodArray<
+        TSchemaType extends {
+          of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any,
+            any
+          >[];
+        }
+          ? MembersZods<TMemberDefinitions, TAliasedZods>[number] | SpanZod
+          : SpanZod
+      >;
+    }
 >;
 
 const blockZod = <
-  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"block", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
-  { of }: TSchemaType,
+  schemaType: TSchemaType,
   getZods: () => TAliasedZods
 ): BlockZod<TSchemaType, TAliasedZods> =>
   z.object({
     ...blockFieldsZods,
+    ...blockCustomFields<TSchemaType>(schemaType),
     children: z.array(
-      !of
+      !schemaType.of
         ? spanZod
         : zodUnion([
             spanZod,
             ...membersZods(
-              of as ArrayMemberDefinition<
+              schemaType.of as ArrayMemberDefinition<
+                any,
                 any,
                 any,
                 any,
@@ -887,11 +945,13 @@ type FieldsZods<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType extends {
   fields?: (infer TFieldDefinition extends FieldDefinition<
+    any,
     any,
     any,
     any,
@@ -908,7 +968,20 @@ type FieldsZods<
   ? {
       [Name in Extract<
         TFieldDefinition,
-        FieldDefinition<any, any, any, any, any, any, any, any, any, any, false>
+        FieldDefinition<
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          false
+        >
       >["name"]]: z.ZodOptional<
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursive
         SchemaTypeToZod<Extract<TFieldDefinition, { name: Name }>, TAliasedZods>
@@ -916,7 +989,20 @@ type FieldsZods<
     } & {
       [Name in Extract<
         TFieldDefinition,
-        FieldDefinition<any, any, any, any, any, any, any, any, any, any, true>
+        FieldDefinition<
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          true
+        >
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursive
       >["name"]]: SchemaTypeToZod<
         Extract<TFieldDefinition, { name: Name }>,
@@ -931,6 +1017,7 @@ const fieldsZods = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -941,6 +1028,7 @@ const fieldsZods = <
   Object.fromEntries(
     (
       fields as FieldDefinition<
+        any,
         any,
         any,
         any,
@@ -971,12 +1059,12 @@ const fieldsZods = <
   ) as FieldsZods<TSchemaType, TAliasedZods>;
 
 type ObjectZod<
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<FieldsZods<TSchemaType, TAliasedZods>>;
 
 const objectZod = <
-  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"object", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -993,14 +1081,14 @@ const documentFieldsZods = {
 };
 
 type DocumentZod<
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   FieldsZods<TSchemaType, TAliasedZods> & typeof documentFieldsZods
 >;
 
 const documentZod = <
-  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"document", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1036,12 +1124,12 @@ const fileFieldsZods = {
 };
 
 type FileZod<
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<FieldsZods<TSchemaType, TAliasedZods> & typeof fileFieldsZods>;
 
 const fileZod = <
-  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"file", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1075,13 +1163,14 @@ const imageHotspotFields = {
 };
 
 type ImageZod<
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
   FieldsZods<TSchemaType, TAliasedZods> &
     typeof imageFieldsZods &
     (TSchemaType extends SchemaTypeDefinition<
       "image",
+      any,
       any,
       any,
       any,
@@ -1094,7 +1183,7 @@ type ImageZod<
 >;
 
 const imageZod = <
-  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<"image", any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1107,7 +1196,7 @@ const imageZod = <
   }) as unknown as ImageZod<TSchemaType, TAliasedZods>;
 
 type AliasZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodLazy<
   TSchemaType["type"] extends keyof TAliasedZods
@@ -1116,7 +1205,7 @@ type AliasZod<
 >;
 
 const aliasZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   { type }: TSchemaType,
@@ -1128,14 +1217,17 @@ const aliasZod = <
   >;
 
 type SchemaTypeToZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType["type"] extends keyof typeof constantZods
   ? (typeof constantZods)[TSchemaType["type"]]
   : TSchemaType["type"] extends "date"
   ? ReturnType<
       typeof dateZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"date", any, any, any, any>>
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"date", any, any, any, any, any>
+        >
       >
     >
   : TSchemaType["type"] extends "datetime"
@@ -1143,14 +1235,17 @@ type SchemaTypeToZod<
       typeof datetimeZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any>
         >
       >
     >
   : TSchemaType["type"] extends "number"
   ? ReturnType<
       typeof numberZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"number", any, any, any, any>>
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"number", any, any, any, any, any>
+        >
       >
     >
   : TSchemaType["type"] extends "reference"
@@ -1158,39 +1253,54 @@ type SchemaTypeToZod<
       typeof referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any>
         >
       >
     >
   : TSchemaType["type"] extends "string"
   ? ReturnType<
       typeof stringZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"string", any, any, any, any>>
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"string", any, any, any, any, any>
+        >
       >
     >
   : TSchemaType["type"] extends "text"
   ? ReturnType<
       typeof textZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"text", any, any, any, any>>
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"text", any, any, any, any, any>
+        >
       >
     >
   : TSchemaType["type"] extends "url"
   ? ReturnType<
       typeof urlZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"url", any, any, any, any>>
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"url", any, any, any, any, any>
+        >
       >
     >
   : TSchemaType["type"] extends "array"
   ? ReturnType<
       typeof arrayZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"array", any, any, any, any>>,
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"array", any, any, any, any, any>
+        >,
         TAliasedZods
       >
     >
   : TSchemaType["type"] extends "block"
   ? ReturnType<
       typeof blockZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"block", any, any, any, any>>,
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"block", any, any, any, any, any>
+        >,
         TAliasedZods
       >
     >
@@ -1199,7 +1309,7 @@ type SchemaTypeToZod<
       typeof objectZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1209,7 +1319,7 @@ type SchemaTypeToZod<
       typeof documentZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1217,21 +1327,27 @@ type SchemaTypeToZod<
   : TSchemaType["type"] extends "file"
   ? ReturnType<
       typeof fileZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"file", any, any, any, any>>,
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"file", any, any, any, any, any>
+        >,
         TAliasedZods
       >
     >
   : TSchemaType["type"] extends "image"
   ? ReturnType<
       typeof imageZod<
-        Extract<TSchemaType, SchemaTypeDefinition<"image", any, any, any, any>>,
+        Extract<
+          TSchemaType,
+          SchemaTypeDefinition<"image", any, any, any, any, any>
+        >,
         TAliasedZods
       >
     >
   : ReturnType<typeof aliasZod<TSchemaType, TAliasedZods>>;
 
 const schemaTypeToZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any>,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1245,56 +1361,56 @@ const schemaTypeToZod = <
     ? dateZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"date", any, any, any, any>
+          SchemaTypeDefinition<"date", any, any, any, any, any>
         >
       )
     : schema.type === "datetime"
     ? datetimeZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any>
         >
       )
     : schema.type === "number"
     ? numberZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"number", any, any, any, any>
+          SchemaTypeDefinition<"number", any, any, any, any, any>
         >
       )
     : schema.type === "reference"
     ? referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any>
         >
       >()
     : schema.type === "string"
     ? stringZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"string", any, any, any, any>
+          SchemaTypeDefinition<"string", any, any, any, any, any>
         >
       )
     : schema.type === "text"
     ? textZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"text", any, any, any, any>
+          SchemaTypeDefinition<"text", any, any, any, any, any>
         >
       )
     : schema.type === "url"
     ? urlZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"url", any, any, any, any>
+          SchemaTypeDefinition<"url", any, any, any, any, any>
         >
       )
     : schema.type === "array"
     ? arrayZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"array", any, any, any, any>
+          SchemaTypeDefinition<"array", any, any, any, any, any>
         >,
         getZods
       )
@@ -1302,7 +1418,7 @@ const schemaTypeToZod = <
     ? blockZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"block", any, any, any, any>
+          SchemaTypeDefinition<"block", any, any, any, any, any>
         >,
         getZods
       )
@@ -1310,7 +1426,7 @@ const schemaTypeToZod = <
     ? objectZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any>
         >,
         getZods
       )
@@ -1318,7 +1434,7 @@ const schemaTypeToZod = <
     ? documentZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any>
         >,
         getZods
       )
@@ -1326,7 +1442,7 @@ const schemaTypeToZod = <
     ? fileZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"file", any, any, any, any>
+          SchemaTypeDefinition<"file", any, any, any, any, any>
         >,
         getZods
       )
@@ -1334,7 +1450,7 @@ const schemaTypeToZod = <
     ? imageZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"image", any, any, any, any>
+          SchemaTypeDefinition<"image", any, any, any, any, any>
         >,
         getZods
       )
@@ -1378,6 +1494,7 @@ export const sanityConfigToZodsTyped = <
   const pluginsZods = plugins
     .map(
       (plugin) =>
+        // @ts-expect-error -- TODO https://github.com/saiichihashimoto/sanity-typed/issues/335
         sanityConfigToZodsTyped(plugin) as SanityConfigZods<TPluginOptions>
     )
     .reduce(
@@ -1418,6 +1535,7 @@ export const sanityDocumentsZod = <const TConfig extends ConfigBase<any, any>>(
 ) => {
   type TTypeDefinition = TConfig extends ConfigBase<
     infer TTypeDefinition extends TypeDefinition<
+      any,
       any,
       any,
       any,

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -923,7 +923,7 @@ const arrayZod = <
 const spanZod = z.object({
   _key: z.string(),
   _type: z.literal("span"),
-  // TODO Only allow marks that correspond to decorators or markDefs
+  // TODO https://github.com/saiichihashimoto/sanity-typed/issues/537
   marks: z.array(z.string()),
   text: z.string(),
 });
@@ -973,9 +973,8 @@ const blockFieldsZods = <
 
   return {
     _type: z.literal("block"),
-    // TODO Only have level if we also have listItem
+    // TODO https://github.com/saiichihashimoto/sanity-typed/issues/538
     level: z.optional(z.number()),
-    // TODO Only allow level & listItem together, never separate
     listItem: typedTernary(
       !lists?.length as Negate<IsStringLiteral<TBlockListItem>>,
       () => z.optional(z.union([z.literal("bullet"), z.literal("number")])),
@@ -1118,7 +1117,7 @@ const blockZod = <
             ),
           ])
     ),
-    // TODO Only allow markDefs who's _key associates with a span's marks[number]
+    // TODO https://github.com/saiichihashimoto/sanity-typed/issues/537
     markDefs: z.array(
       !schemaType.marks?.annotations
         ? z.never()

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -13,6 +13,7 @@ import { referenced } from "@sanity-typed/types";
 import type {
   ArrayMemberDefinition,
   ConfigBase,
+  DefinitionBase,
   DocumentValues,
   FieldDefinition,
   MaybeTitledListValue,
@@ -28,6 +29,9 @@ type SchemaTypeDefinition<
   TReferenced extends string,
   TBlockStyle extends string,
   TBlockListItem extends string,
+  TBlockMarkAnnotation extends DefinitionBase<any, any, any> & {
+    name?: string;
+  },
   THotspot extends boolean
 > =
   | ArrayMemberDefinition<
@@ -40,6 +44,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any,
@@ -55,6 +60,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any,
@@ -70,6 +76,7 @@ type SchemaTypeDefinition<
       TReferenced,
       TBlockStyle,
       TBlockListItem,
+      TBlockMarkAnnotation,
       THotspot,
       any,
       any
@@ -122,7 +129,16 @@ const toZodType = <Output, Input>(
 ) => zod as z.ZodType<Output, z.ZodTypeDef, Input>;
 
 const dateZod = <
-  TSchemaType extends SchemaTypeDefinition<"date", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "date",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -152,6 +168,7 @@ const dateZod = <
 const datetimeZod = <
   TSchemaType extends SchemaTypeDefinition<
     "datetime",
+    any,
     any,
     any,
     any,
@@ -192,6 +209,7 @@ const numberZod = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -202,6 +220,7 @@ const numberZod = <
   type TNumberValue = TSchemaType extends SchemaTypeDefinition<
     "number",
     infer TNumberValue,
+    any,
     any,
     any,
     any,
@@ -264,6 +283,7 @@ const referenceZod = <
     any,
     any,
     any,
+    any,
     any
   >
 >() =>
@@ -275,6 +295,7 @@ const referenceZod = <
           any,
           any,
           infer TReferenced,
+          any,
           any,
           any,
           any
@@ -302,6 +323,7 @@ const referenceZod = <
 const stringAndTextZod = <
   TSchemaType extends SchemaTypeDefinition<
     "string" | "text",
+    any,
     any,
     any,
     any,
@@ -391,6 +413,7 @@ const stringZod = <
     any,
     any,
     any,
+    any,
     any
   >
 >(
@@ -400,6 +423,7 @@ const stringZod = <
     "string",
     any,
     infer TStringValue,
+    any,
     any,
     any,
     any,
@@ -431,7 +455,16 @@ const stringZod = <
 };
 
 const textZod = <
-  TSchemaType extends SchemaTypeDefinition<"text", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "text",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => stringAndTextZod(schemaType);
@@ -439,7 +472,16 @@ const textZod = <
 const DUMMY_ORIGIN = "http://sanity";
 
 const urlZod = <
-  TSchemaType extends SchemaTypeDefinition<"url", any, any, any, any, any, any>
+  TSchemaType extends SchemaTypeDefinition<
+    "url",
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >
 >(
   schemaType: TSchemaType
 ) => {
@@ -678,10 +720,12 @@ type MembersZods<
     any,
     any,
     any,
+    any,
     any
   >[],
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TMemberDefinitions extends (infer TMemberDefinition extends ArrayMemberDefinition<
+  any,
   any,
   any,
   any,
@@ -709,6 +753,7 @@ type MembersZods<
 
 const membersZods = <
   TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -789,11 +834,13 @@ type ArrayZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType extends {
   of: infer TMemberDefinitions extends ArrayMemberDefinition<
+    any,
     any,
     any,
     any,
@@ -821,6 +868,7 @@ type ArrayZod<
 const arrayZod = <
   TSchemaType extends SchemaTypeDefinition<
     "array",
+    any,
     any,
     any,
     any,
@@ -875,27 +923,17 @@ const arrayZod = <
 const spanZod = z.object({
   _key: z.string(),
   _type: z.literal("span"),
-  marks: z.optional(z.array(z.string())),
+  // TODO Only allow marks that correspond to decorators or markDefs
+  marks: z.array(z.string()),
   text: z.string(),
 });
 
 type SpanZod = typeof spanZod;
 
-const blockFieldsZods = {
-  _type: z.literal("block"),
-  // TODO Only have level if we also have listItem
-  level: z.optional(z.number()),
-  markDefs: z.array(
-    z.object({
-      _key: z.string(),
-      _type: z.string(),
-    })
-  ),
-};
-
-const blockCustomFields = <
+const blockFieldsZods = <
   TSchemaType extends SchemaTypeDefinition<
     "block",
+    any,
     any,
     any,
     any,
@@ -914,6 +952,7 @@ const blockCustomFields = <
     any,
     infer TBlockStyle,
     any,
+    any,
     any
   >
     ? TBlockStyle
@@ -926,12 +965,16 @@ const blockCustomFields = <
     any,
     any,
     infer TBlockListItem,
+    any,
     any
   >
     ? TBlockListItem
     : never;
 
   return {
+    _type: z.literal("block"),
+    // TODO Only have level if we also have listItem
+    level: z.optional(z.number()),
     // TODO Only allow level & listItem together, never separate
     listItem: typedTernary(
       !lists?.length as Negate<IsStringLiteral<TBlockListItem>>,
@@ -976,15 +1019,39 @@ type BlockZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodObject<
-  ReturnType<typeof blockCustomFields<TSchemaType>> &
-    typeof blockFieldsZods & {
-      children: z.ZodArray<
-        TSchemaType extends {
-          of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+  ReturnType<typeof blockFieldsZods<TSchemaType>> & {
+    children: z.ZodArray<
+      TSchemaType extends {
+        of?: infer TMemberDefinitions extends ArrayMemberDefinition<
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any
+        >[];
+      }
+        ? MembersZods<TMemberDefinitions, TAliasedZods>[number] | SpanZod
+        : SpanZod
+    >;
+    markDefs: z.ZodArray<
+      TSchemaType extends {
+        marks?: {
+          annotations?: infer TBlockMarkAnnotations extends ArrayMemberDefinition<
+            any,
             any,
             any,
             any,
@@ -999,16 +1066,18 @@ type BlockZod<
             any,
             any
           >[];
-        }
-          ? MembersZods<TMemberDefinitions, TAliasedZods>[number] | SpanZod
-          : SpanZod
-      >;
-    }
+        };
+      }
+        ? MembersZods<TBlockMarkAnnotations, TAliasedZods>[number]
+        : never
+    >;
+  }
 >;
 
 const blockZod = <
   TSchemaType extends SchemaTypeDefinition<
     "block",
+    any,
     any,
     any,
     any,
@@ -1022,8 +1091,7 @@ const blockZod = <
   getZods: () => TAliasedZods
 ): BlockZod<TSchemaType, TAliasedZods> =>
   z.object({
-    ...blockFieldsZods,
-    ...blockCustomFields<TSchemaType>(schemaType),
+    ...blockFieldsZods<TSchemaType>(schemaType),
     children: z.array(
       !schemaType.of
         ? spanZod
@@ -1043,17 +1111,45 @@ const blockZod = <
                 any,
                 any,
                 any,
+                any,
                 any
               >[],
               getZods
             ),
           ])
     ),
+    // TODO Only allow markDefs who's _key associates with a span's marks[number]
+    markDefs: z.array(
+      !schemaType.marks?.annotations
+        ? z.never()
+        : zodUnion(
+            membersZods(
+              schemaType.marks.annotations as ArrayMemberDefinition<
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any
+              >[],
+              getZods
+            )
+          )
+    ),
   }) as BlockZod<TSchemaType, TAliasedZods>;
 
 type FieldsZods<
   TSchemaType extends SchemaTypeDefinition<
     "document" | "file" | "image" | "object",
+    any,
     any,
     any,
     any,
@@ -1076,6 +1172,7 @@ type FieldsZods<
     any,
     any,
     any,
+    any,
     any
   >)[];
 }
@@ -1083,6 +1180,7 @@ type FieldsZods<
       [Name in Extract<
         TFieldDefinition,
         FieldDefinition<
+          any,
           any,
           any,
           any,
@@ -1117,6 +1215,7 @@ type FieldsZods<
           any,
           any,
           any,
+          any,
           true
         >
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursive
@@ -1135,6 +1234,7 @@ const fieldsZods = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1145,6 +1245,7 @@ const fieldsZods = <
   Object.fromEntries(
     (
       fields as FieldDefinition<
+        any,
         any,
         any,
         any,
@@ -1184,6 +1285,7 @@ type ObjectZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1192,6 +1294,7 @@ type ObjectZod<
 const objectZod = <
   TSchemaType extends SchemaTypeDefinition<
     "object",
+    any,
     any,
     any,
     any,
@@ -1222,6 +1325,7 @@ type DocumentZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1232,6 +1336,7 @@ type DocumentZod<
 const documentZod = <
   TSchemaType extends SchemaTypeDefinition<
     "document",
+    any,
     any,
     any,
     any,
@@ -1281,6 +1386,7 @@ type FileZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1289,6 +1395,7 @@ type FileZod<
 const fileZod = <
   TSchemaType extends SchemaTypeDefinition<
     "file",
+    any,
     any,
     any,
     any,
@@ -1336,6 +1443,7 @@ type ImageZod<
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1344,6 +1452,7 @@ type ImageZod<
     typeof imageFieldsZods &
     (TSchemaType extends SchemaTypeDefinition<
       "image",
+      any,
       any,
       any,
       any,
@@ -1365,6 +1474,7 @@ const imageZod = <
     any,
     any,
     any,
+    any,
     any
   >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
@@ -1379,7 +1489,16 @@ const imageZod = <
   }) as unknown as ImageZod<TSchemaType, TAliasedZods>;
 
 type AliasZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = z.ZodLazy<
   TSchemaType["type"] extends keyof TAliasedZods
@@ -1388,7 +1507,16 @@ type AliasZod<
 >;
 
 const aliasZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   { type }: TSchemaType,
@@ -1400,7 +1528,16 @@ const aliasZod = <
   >;
 
 type SchemaTypeToZod<
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 > = TSchemaType["type"] extends keyof typeof constantZods
   ? (typeof constantZods)[TSchemaType["type"]]
@@ -1409,7 +1546,7 @@ type SchemaTypeToZod<
       typeof dateZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"date", any, any, any, any, any, any>
+          SchemaTypeDefinition<"date", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1418,7 +1555,7 @@ type SchemaTypeToZod<
       typeof datetimeZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1427,7 +1564,7 @@ type SchemaTypeToZod<
       typeof numberZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"number", any, any, any, any, any, any>
+          SchemaTypeDefinition<"number", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1436,7 +1573,7 @@ type SchemaTypeToZod<
       typeof referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1445,7 +1582,7 @@ type SchemaTypeToZod<
       typeof stringZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"string", any, any, any, any, any, any>
+          SchemaTypeDefinition<"string", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1454,7 +1591,7 @@ type SchemaTypeToZod<
       typeof textZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"text", any, any, any, any, any, any>
+          SchemaTypeDefinition<"text", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1463,7 +1600,7 @@ type SchemaTypeToZod<
       typeof urlZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"url", any, any, any, any, any, any>
+          SchemaTypeDefinition<"url", any, any, any, any, any, any, any>
         >
       >
     >
@@ -1472,7 +1609,7 @@ type SchemaTypeToZod<
       typeof arrayZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"array", any, any, any, any, any, any>
+          SchemaTypeDefinition<"array", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1482,7 +1619,7 @@ type SchemaTypeToZod<
       typeof blockZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"block", any, any, any, any, any, any>
+          SchemaTypeDefinition<"block", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1492,7 +1629,7 @@ type SchemaTypeToZod<
       typeof objectZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1502,7 +1639,7 @@ type SchemaTypeToZod<
       typeof documentZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1512,7 +1649,7 @@ type SchemaTypeToZod<
       typeof fileZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"file", any, any, any, any, any, any>
+          SchemaTypeDefinition<"file", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1522,7 +1659,7 @@ type SchemaTypeToZod<
       typeof imageZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"image", any, any, any, any, any, any>
+          SchemaTypeDefinition<"image", any, any, any, any, any, any, any>
         >,
         TAliasedZods
       >
@@ -1530,7 +1667,16 @@ type SchemaTypeToZod<
   : ReturnType<typeof aliasZod<TSchemaType, TAliasedZods>>;
 
 const schemaTypeToZod = <
-  TSchemaType extends SchemaTypeDefinition<any, any, any, any, any, any, any>,
+  TSchemaType extends SchemaTypeDefinition<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any
+  >,
   TAliasedZods extends { [name: string]: z.ZodTypeAny }
 >(
   schema: TSchemaType,
@@ -1544,56 +1690,56 @@ const schemaTypeToZod = <
     ? dateZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"date", any, any, any, any, any, any>
+          SchemaTypeDefinition<"date", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "datetime"
     ? datetimeZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"datetime", any, any, any, any, any, any>
+          SchemaTypeDefinition<"datetime", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "number"
     ? numberZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"number", any, any, any, any, any, any>
+          SchemaTypeDefinition<"number", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "reference"
     ? referenceZod<
         Extract<
           TSchemaType,
-          SchemaTypeDefinition<"reference", any, any, any, any, any, any>
+          SchemaTypeDefinition<"reference", any, any, any, any, any, any, any>
         >
       >()
     : schema.type === "string"
     ? stringZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"string", any, any, any, any, any, any>
+          SchemaTypeDefinition<"string", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "text"
     ? textZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"text", any, any, any, any, any, any>
+          SchemaTypeDefinition<"text", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "url"
     ? urlZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"url", any, any, any, any, any, any>
+          SchemaTypeDefinition<"url", any, any, any, any, any, any, any>
         >
       )
     : schema.type === "array"
     ? arrayZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"array", any, any, any, any, any, any>
+          SchemaTypeDefinition<"array", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1601,7 +1747,7 @@ const schemaTypeToZod = <
     ? blockZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"block", any, any, any, any, any, any>
+          SchemaTypeDefinition<"block", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1609,7 +1755,7 @@ const schemaTypeToZod = <
     ? objectZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"object", any, any, any, any, any, any>
+          SchemaTypeDefinition<"object", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1617,7 +1763,7 @@ const schemaTypeToZod = <
     ? documentZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"document", any, any, any, any, any, any>
+          SchemaTypeDefinition<"document", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1625,7 +1771,7 @@ const schemaTypeToZod = <
     ? fileZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"file", any, any, any, any, any, any>
+          SchemaTypeDefinition<"file", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1633,7 +1779,7 @@ const schemaTypeToZod = <
     ? imageZod(
         schema as Extract<
           TSchemaType,
-          SchemaTypeDefinition<"image", any, any, any, any, any, any>
+          SchemaTypeDefinition<"image", any, any, any, any, any, any, any>
         >,
         getZods
       )
@@ -1719,6 +1865,7 @@ export const sanityDocumentsZod = <const TConfig extends ConfigBase<any, any>>(
 ) => {
   type TTypeDefinition = TConfig extends ConfigBase<
     infer TTypeDefinition extends TypeDefinition<
+      any,
       any,
       any,
       any,


### PR DESCRIPTION
Strongly type everything we can on `block` types.

Refactored `TOptionsHelper` out of there. It was becoming way too overloaded and wouldn't work for what I needed. Having a thousand generics isn't ideal but I can't think of a better path.