### PR TITLE
add repro for zod parser stripping out unknown keys on markdefs

### DIFF
--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -646,7 +646,7 @@ const extendViaIntersection =
   <Shape extends z.ZodRawShape>(shape: Shape) =>
   <Zod extends z.ZodTypeAny>(zod: Zod): ExtendViaIntersection<Zod, Shape> =>
     (zod instanceof z.ZodObject
-      ? zod.extend(shape)
+      ? zod.extend(shape).passthrough()
       : zod instanceof z.ZodLazy
       ? z.lazy(() =>
           extendViaIntersection(shape)(

--- a/packages/zod/src/specific-issues.test.ts
+++ b/packages/zod/src/specific-issues.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "@jest/globals";
+import { expectType } from "@saiichihashimoto/test-utils";
+
+import {
+  defineArrayMember,
+  defineConfig,
+  defineField,
+  defineType,
+} from "@sanity-typed/types";
+import type { InferSchemaValues, PortableTextBlock } from "@sanity-typed/types";
+
+import { sanityConfigToZodsTyped } from "./internal";
+
+const fields: Omit<PortableTextBlock, "_type" | "children"> = {
+  level: 1,
+  listItem: "bullet",
+  markDefs: [],
+  style: "normal",
+};
+
+describe("specific issues", () => {
+  it("#559: zod parser strings untyped block markDefs", () => {
+    const config = defineConfig({
+      dataset: "dataset",
+      projectId: "projectId",
+      schema: {
+        types: [
+          defineType({
+            name: "foo",
+            type: "block",
+            marks: {
+              annotations: [
+                defineArrayMember({
+                  name: "internalLink",
+                  type: "object",
+                  fields: [
+                    defineField({
+                      name: "reference",
+                      type: "reference",
+                      to: [{ type: "post" as const }],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          }),
+        ],
+      },
+    });
+    const zods = sanityConfigToZodsTyped(config);
+
+    const unparsed = {
+      ...fields,
+      _type: "foo",
+      children: [
+        { _key: "key", _type: "span", marks: ["mark-key"], text: "text" },
+      ],
+      markDefs: [
+        {
+          _key: "mark-key",
+          _type: "internalLink",
+          internalLink: {
+            _ref: "052a9ccc-ba1f-4e8e-adb4-4be196815746",
+            _type: "reference",
+          },
+          slug: {
+            _type: "slug",
+            current: "foo-bar-test",
+          },
+          postType: "post",
+        },
+      ],
+    };
+
+    const parsed = zods.foo.parse(unparsed);
+    expect(parsed).toStrictEqual(unparsed);
+    expectType<typeof parsed>().toEqual<
+      InferSchemaValues<typeof config>["foo"]
+    >();
+  });
+});


### PR DESCRIPTION
Well... I made the repro from #559 , but I found a place in the code that "works" as a fix. I don't understand all of the implications, but it is at least a start 🤷 

I need this to use some sort of `passthrough`, as without it, I can't upgrade 😬 