### PR TITLE
fix(createClient): createClient no longer uses the double function signature

### DIFF
--- a/packages/client-mock/README.md
+++ b/packages/client-mock/README.md
@@ -275,7 +275,7 @@ Removing the double function signature from `createClient`:
 });
 ```
 
-This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 
 ## Alternatives
 

--- a/packages/client-mock/README.md
+++ b/packages/client-mock/README.md
@@ -21,6 +21,9 @@ Mock [@sanity-typed/client](../client) for local development and testing
 - [Considerations](#considerations)
   - [GROQ Query results changes in seemingly breaking ways](#groq-query-results-changes-in-seemingly-breaking-ways)
   - [`Type instantiation is excessively deep and possibly infinite`](#type-instantiation-is-excessively-deep-and-possibly-infinite)
+- [Breaking Changes](#breaking-changes)
+  - [1 to 2](#1-to-2)
+    - [No more `createClient<SanityValues>()(config)`](#no-more-createclientsanityvaluesconfig)
 - [Alternatives](#alternatives)
 
 ## Install
@@ -133,10 +136,9 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity-typed/client";
 import { createClient } from "@sanity-typed/client-mock";
 
-/** Small change using createClient */
 // export const client = createClient({
 export const client = createClient<SanityValues>({
-  dataset: [
+  documents: [
     {
       _createdAt: "2011-12-15T03:57:59.213Z",
       _id: "id",
@@ -155,7 +157,8 @@ export const client = createClient<SanityValues>({
     },
     // ...
   ],
-})({
+
+  // ...@sanity/client options
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,
@@ -220,16 +223,16 @@ import { createClient as createMockClient } from "@sanity-typed/client-mock";
 
 import { getMockDataset } from "./mocks";
 
-const createClient = process.env.VERCEL
-  ? createLiveClient<SanityValues>()
-  : createMockClient<SanityValues>({ dataset: getMockDataset() });
-
-export const client = createClient({
+const config = {
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,
   apiVersion: "2023-05-23",
-});
+};
+
+export const client = process.env.VERCEL
+  ? createLiveClient<SanityValues>(config)
+  : createMockClient<SanityValues>({ ...config, documents: getMockDataset() });
 
 export const makeTypedQuery = async () =>
   client.fetch('*[_type=="product"]{_id,productName,tags}');
@@ -256,6 +259,23 @@ You might run into the dreaded `Type instantiation is excessively deep and possi
 
 People will sometimes create a repo with their issue. _Please_ open a PR with a minimal test instead. Without a PR there will be no tests reflecting your issue and it may appear again in a regression. Forking a github repo to make a PR is a more welcome way to contribute to an open source library.
 <!-- <<<<<< END INCLUDED FILE (markdown): SOURCE docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md -->
+
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 
 ## Alternatives
 

--- a/packages/client-mock/README.md
+++ b/packages/client-mock/README.md
@@ -266,11 +266,15 @@ People will sometimes create a repo with their issue. _Please_ open a PR with a 
 
 #### No more `createClient<SanityValues>()(config)`
 
-Removing the double function signature from `createClient`:
+Removing the double function signature from `createClient` and renaming `dataset` to `documents`:
 
 ```diff
-- const client = createClient<SanityValues>()({
+- const client = createClient<SanityValues>({
+-   dataset: [/* ... */],
+- })({
 + const client = createClient<SanityValues>({
++ documents: [/* ... */],
+  dataset: "production",
   // ...
 });
 ```

--- a/packages/client-mock/_README.md
+++ b/packages/client-mock/_README.md
@@ -46,11 +46,15 @@ Depending on your tree-shaking setup, you'll want to swap between the real clien
 
 #### No more `createClient<SanityValues>()(config)`
 
-Removing the double function signature from `createClient`:
+Removing the double function signature from `createClient` and renaming `dataset` to `documents`:
 
 ```diff
-- const client = createClient<SanityValues>()({
+- const client = createClient<SanityValues>({
+-   dataset: [/* ... */],
+- })({
 + const client = createClient<SanityValues>({
++ documents: [/* ... */],
+  dataset: "production",
   // ...
 });
 ```

--- a/packages/client-mock/_README.md
+++ b/packages/client-mock/_README.md
@@ -40,6 +40,23 @@ Depending on your tree-shaking setup, you'll want to swap between the real clien
 @[:markdown](../../docs/considerations/evaluate-type-flakiness.md)
 @[:markdown](../../docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md)
 
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
+
 ## Alternatives
 
 - [`fake-sanity-client`](https://www.npmjs.com/package/fake-sanity-client)

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -38,7 +38,7 @@ npm install sanity @sanity-typed/client
 
 ## Usage
 
-Use `createClient` exactly as you would from [`@sanity/client`](https://github.com/sanity-io/client) with a minor change for proper type inference.
+Use `createClient` exactly as you would from [`@sanity/client`](https://github.com/sanity-io/client).
 
 <!-- >>>>>> BEGIN INCLUDED FILE (typescript): SOURCE packages/example-studio/schemas/product.ts -->
 ```product.ts```:
@@ -180,7 +180,6 @@ const client = createClient({
   // ...
 });
 
-// Same function signature as the typed `createClient`
 const typedClient = castToTyped<SanityValues>()(client);
 
 // Also, if you need the config in the client (eg. for queries using $param),

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -24,6 +24,8 @@
   - [GROQ Query results changes in seemingly breaking ways](#groq-query-results-changes-in-seemingly-breaking-ways)
   - [`Type instantiation is excessively deep and possibly infinite`](#type-instantiation-is-excessively-deep-and-possibly-infinite)
 - [Breaking Changes](#breaking-changes)
+  - [2 to 3](#2-to-3)
+    - [No more `createClient<SanityValues>()(config)`](#no-more-createclientsanityvaluesconfig)
   - [1 to 2](#1-to-2)
     - [Removal of `castFromTyped`](#removal-of-castfromtyped)
 - [Alternatives](#alternatives)
@@ -138,9 +140,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity/client";
 import { createClient } from "@sanity-typed/client";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,
@@ -163,8 +164,6 @@ export const makeTypedQuery = async () =>
  */
 ```
 <!-- <<<<<< END INCLUDED FILE (typescript): SOURCE packages/example-app/src/sanity/client.ts -->
-
-The `createClient<SanityValues>()(config)` syntax is due to having to infer one generic (the config shape) while explicitly providing the Sanity Values' type, [which can't be done in the same generics](https://github.com/microsoft/TypeScript/issues/10571).
 
 ## Typing an untyped client (and vice versa)
 
@@ -220,7 +219,7 @@ import { createClient } from "@sanity-typed/client";
 
 import type { SanityValues } from "./sanity.config";
 
-const client = createClient<SanityValues>()({
+const client = createClient<SanityValues>({
   // ...
 });
 
@@ -284,6 +283,21 @@ People will sometimes create a repo with their issue. _Please_ open a PR with a 
 <!-- <<<<<< END INCLUDED FILE (markdown): SOURCE docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md -->
 
 ## Breaking Changes
+
+### 2 to 3
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 
 ### 1 to 2
 

--- a/packages/client/_README.md
+++ b/packages/client/_README.md
@@ -24,7 +24,7 @@ npm install sanity @sanity-typed/client
 
 ## Usage
 
-Use `createClient` exactly as you would from [`@sanity/client`](https://github.com/sanity-io/client) with a minor change for proper type inference.
+Use `createClient` exactly as you would from [`@sanity/client`](https://github.com/sanity-io/client).
 
 @[typescript](../example-studio/schemas/product.ts)
 @[typescript](../example-studio/sanity.config.ts)
@@ -45,7 +45,6 @@ const client = createClient({
   // ...
 });
 
-// Same function signature as the typed `createClient`
 const typedClient = castToTyped<SanityValues>()(client);
 
 // Also, if you need the config in the client (eg. for queries using $param),

--- a/packages/client/_README.md
+++ b/packages/client/_README.md
@@ -30,8 +30,6 @@ Use `createClient` exactly as you would from [`@sanity/client`](https://github.c
 @[typescript](../example-studio/sanity.config.ts)
 @[typescript](../example-app/src/sanity/client.ts)
 
-The `createClient<SanityValues>()(config)` syntax is due to having to infer one generic (the config shape) while explicitly providing the Sanity Values' type, [which can't be done in the same generics](https://github.com/microsoft/TypeScript/issues/10571).
-
 ## Typing an untyped client (and vice versa)
 
 Sometimes, you'll have a preconfigured client from a separate library that you will still want typed results from. A `castToTyped` function is provided to do just that.
@@ -86,7 +84,7 @@ import { createClient } from "@sanity-typed/client";
 
 import type { SanityValues } from "./sanity.config";
 
-const client = createClient<SanityValues>()({
+const client = createClient<SanityValues>({
   // ...
 });
 
@@ -104,6 +102,21 @@ export default untypedClient;
 @[:markdown](../../docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md)
 
 ## Breaking Changes
+
+### 2 to 3
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 
 ### 1 to 2
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import type {
-  ClientConfig,
-  ClientPerspective,
-  RequestFetchOptions,
+  InitializedClientConfig,
   SanityAssetDocument,
 } from "@sanity/client";
 import type { Observable } from "rxjs";
@@ -24,39 +22,10 @@ describe("createClient", () => {
     const exec = () =>
       createClient<{
         foo: AnySanityDocument & { _type: "foo"; foo: string };
-      }>()({});
+      }>({});
 
     expectType<ReturnType<typeof exec>>().toEqual<
-      SanityClient<
-        { [key: string]: never },
-        AnySanityDocument & { _type: "foo"; foo: string }
-      >
-    >();
-  });
-
-  it("adds _originalId to documents when perspective is `previewDrafts`", () => {
-    const exec = () =>
-      createClient<{
-        foo: AnySanityDocument & { _type: "foo"; foo: string };
-        qux: AnySanityDocument & { _type: "qux"; qux: number };
-      }>()({
-        perspective: "previewDrafts",
-      });
-
-    expectType<ReturnType<typeof exec>>().toEqual<
-      SanityClient<
-        {
-          perspective: "previewDrafts";
-        },
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "foo";
-          })
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "qux";
-          })
-      >
+      SanityClient<AnySanityDocument & { _type: "foo"; foo: string }>
     >();
   });
 
@@ -65,12 +34,12 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({});
+        }>({});
 
       const execClone = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).clone();
+        }>({}).clone();
 
       expectType<ReturnType<typeof execClone>>().toEqual<
         ReturnType<typeof exec>
@@ -81,42 +50,21 @@ describe("createClient", () => {
   describe("config", () => {
     it("returns the config with more", () => {
       const exec = () =>
-        createClient()({
+        createClient({
           dataset: "dataset",
           projectId: "projectId",
         }).config();
 
-      expectType<ReturnType<typeof exec>>().toStrictEqual<{
-        allowReconfigure?: boolean;
-        apiHost: string;
-        apiVersion: string;
-        cdnUrl: string;
-        dataset: "dataset";
-        fetch?: RequestFetchOptions | boolean;
-        ignoreBrowserTokenWarning?: boolean;
-        isDefaultApi: boolean;
-        maxRetries?: number;
-        perspective?: ClientPerspective;
-        projectId: "projectId";
-        proxy?: string;
-        requestTagPrefix?: string;
-        requester?: Required<ClientConfig>["requester"];
-        resultSourceMap?: boolean | "withKeyArraySelector";
-        retryDelay?: (attemptNumber: number) => number;
-        timeout?: number;
-        token?: string;
-        url: string;
-        useCdn: boolean;
-        useProjectHostname: boolean;
-        withCredentials?: boolean;
-      }>();
+      expectType<
+        ReturnType<typeof exec>
+      >().toStrictEqual<InitializedClientConfig>();
     });
 
     it("returns the altered type", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -124,7 +72,7 @@ describe("createClient", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).config({
@@ -142,7 +90,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -150,7 +98,7 @@ describe("createClient", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).withConfig({
@@ -168,7 +116,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
@@ -180,33 +128,22 @@ describe("createClient", () => {
         createClient<{
           bar: { _type: "bar"; bar: "bar" };
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
       >();
     });
 
-    it("uses the client in queries", () => {
-      const exec = () =>
-        createClient()({
-          projectId: "projectId",
-        }).fetch("sanity::projectId()");
-
-      expectType<ReturnType<typeof exec>>().toStrictEqual<
-        Promise<"projectId">
-      >();
-    });
-
     it("uses the params in queries", () => {
-      const exec = () => createClient()({}).fetch("$param", { param: "foo" });
+      const exec = () => createClient({}).fetch("$param", { param: "foo" });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<Promise<"foo">>();
     });
 
     it("returns RawQueryResponse", () => {
       const exec = () =>
-        createClient()({}).fetch("5", undefined, { filterResponse: false });
+        createClient({}).fetch("5", undefined, { filterResponse: false });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<RawQueryResponse<5, "5">>
@@ -219,7 +156,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*");
+        }>({}).listen("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -232,7 +169,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*", {}, {});
+        }>({}).listen("*", {}, {});
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -248,7 +185,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocument("id");
+        }>({}).getDocument("id");
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -274,7 +211,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocuments(["id", "id2"]);
+        }>({}).getDocuments(["id", "id2"]);
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -317,7 +254,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.create>[0]>().toEqual<
           | Omit<
@@ -351,7 +288,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createOrReplace>[0]>().toEqual<
           | Omit<
@@ -379,7 +316,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createIfNotExists>[0]>().toEqual<
           | Omit<
@@ -411,7 +348,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).delete("id");
+        }>({}).delete("id");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -429,7 +366,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .commit();
 
@@ -447,7 +384,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .set({ foo: "bar" })
             .commit();
@@ -462,7 +399,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { set: { foo: "bar" } })
             .commit();
 
@@ -478,7 +415,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .setIfMissing({ foo: "bar" })
             .commit();
@@ -493,7 +430,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { setIfMissing: { foo: "bar" } })
             .commit();
 
@@ -509,7 +446,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .diffMatchPatch({ foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" })
             .commit();
@@ -524,7 +461,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", {
               diffMatchPatch: { foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" },
             })
@@ -542,7 +479,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .unset(["foo"])
             .commit();
@@ -557,7 +494,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { unset: ["foo"] })
             .commit();
 
@@ -573,7 +510,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .inc({ foo: 1 })
             .commit();
@@ -588,7 +525,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { inc: { foo: 1 } })
             .commit();
 
@@ -604,7 +541,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .dec({ foo: 1 })
             .commit();
@@ -619,7 +556,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { dec: { foo: 1 } })
             .commit();
 
@@ -642,7 +579,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .set({ foo: "bar" })
           .reset()
@@ -665,7 +602,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .commit();
 
@@ -678,7 +615,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<Parameters<typeof transaction.create>[0]>().toEqual<
             | Omit<
@@ -710,7 +647,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ create: { _type: "foo", foo: "foo" } }])
             .commit();
 
@@ -726,7 +663,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createOrReplace>[0]
@@ -756,7 +693,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createOrReplace: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -774,7 +711,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createIfNotExists>[0]
@@ -804,7 +741,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createIfNotExists: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -822,7 +759,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .delete("id")
             .commit();
@@ -841,7 +778,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ delete: { id: "id" } }])
             .commit();
 
@@ -861,7 +798,7 @@ describe("createClient", () => {
           const client = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({});
+          }>({});
 
           return client
             .transaction()
@@ -879,7 +816,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .patch("id", (patch) => patch.set({ foo: "foo" }))
             .commit();
@@ -894,7 +831,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ patch: { id: "id", set: { foo: "foo" } } }])
             .commit();
 
@@ -910,7 +847,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .create({ _type: "foo", foo: "foo" })
           .reset()
@@ -926,7 +863,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([]);
+        }>({}).mutate([]);
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -941,7 +878,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([
+        }>({}).mutate([
           {
             create: {
               _type: "foo",
@@ -962,7 +899,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Patch("id").set({ foo: "bar" }));
+        }>({}).mutate(new Patch("id").set({ foo: "bar" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>
@@ -974,7 +911,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
+        }>({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,4 @@
 export type {
-  InitializedClientConfig,
   ListenEvent,
   Mutation,
   MutationEvent,

--- a/packages/client/src/interoperability.test.ts
+++ b/packages/client/src/interoperability.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import { createClient as createClientNative } from "@sanity/client";
-import type { ClientConfig } from "@sanity/client";
 import { createClient as createStegaClientNative } from "@sanity/client/stega";
 
 import type { AnySanityDocument } from "@sanity-typed/types/src/internal";
@@ -27,7 +26,7 @@ describe("interoperability", () => {
         };
 
         expectType<ReturnType<typeof exec>>().toStrictEqual<
-          SanityClient<ClientConfig, never>
+          SanityClient<never>
         >();
       });
 
@@ -46,7 +45,7 @@ describe("interoperability", () => {
         };
 
         expectType<ReturnType<typeof exec>>().toEqual<
-          SanityClient<ClientConfig, AnySanityDocument & { _type: "foo" }>
+          SanityClient<AnySanityDocument & { _type: "foo" }>
         >();
       });
 
@@ -58,24 +57,14 @@ describe("interoperability", () => {
             createClientNative({
               dataset: "dataset",
               projectId: "projectId",
-            }),
-            {
-              dataset: "dataset",
-              projectId: "projectId",
-            }
+            })
           );
 
           return client;
         };
 
         expectType<ReturnType<typeof exec>>().toEqual<
-          SanityClient<
-            {
-              dataset: "dataset";
-              projectId: "projectId";
-            },
-            AnySanityDocument & { _type: "foo" }
-          >
+          SanityClient<AnySanityDocument & { _type: "foo" }>
         >();
       });
     });
@@ -96,7 +85,7 @@ describe("interoperability", () => {
         };
 
         expectType<ReturnType<typeof exec>>().toStrictEqual<
-          SanityStegaClient<ClientConfig, never>
+          SanityStegaClient<never>
         >();
       });
 
@@ -115,7 +104,7 @@ describe("interoperability", () => {
         };
 
         expectType<ReturnType<typeof exec>>().toEqual<
-          SanityStegaClient<ClientConfig, AnySanityDocument & { _type: "foo" }>
+          SanityStegaClient<AnySanityDocument & { _type: "foo" }>
         >();
       });
 
@@ -127,24 +116,14 @@ describe("interoperability", () => {
             createStegaClientNative({
               dataset: "dataset",
               projectId: "projectId",
-            }),
-            {
-              dataset: "dataset",
-              projectId: "projectId",
-            }
+            })
           );
 
           return client;
         };
 
         expectType<ReturnType<typeof exec>>().toEqual<
-          SanityStegaClient<
-            {
-              dataset: "dataset";
-              projectId: "projectId";
-            },
-            AnySanityDocument & { _type: "foo" }
-          >
+          SanityStegaClient<AnySanityDocument & { _type: "foo" }>
         >();
       });
     });

--- a/packages/client/src/observable.test.ts
+++ b/packages/client/src/observable.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import type {
-  ClientConfig,
-  ClientPerspective,
-  RequestFetchOptions,
+  InitializedClientConfig,
   SanityAssetDocument,
 } from "@sanity/client";
 import type { Observable } from "rxjs";
@@ -25,7 +23,7 @@ describe("observable", () => {
       createClient<{
         foo: AnySanityDocument & { _type: "foo"; foo: string };
         qux: AnySanityDocument & { _type: "qux"; qux: number };
-      }>()({
+      }>({
         perspective: "previewDrafts",
       }).observable;
 
@@ -51,12 +49,12 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable;
+        }>({}).observable;
 
       const execClone = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.clone();
+        }>({}).observable.clone();
 
       expectType<ReturnType<typeof execClone>>().toEqual<
         ReturnType<typeof exec>
@@ -67,42 +65,21 @@ describe("observable", () => {
   describe("config", () => {
     it("returns the config with more", () => {
       const exec = () =>
-        createClient()({
+        createClient({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.config();
 
-      expectType<ReturnType<typeof exec>>().toStrictEqual<{
-        allowReconfigure?: boolean;
-        apiHost: string;
-        apiVersion: string;
-        cdnUrl: string;
-        dataset: "dataset";
-        fetch?: RequestFetchOptions | boolean;
-        ignoreBrowserTokenWarning?: boolean;
-        isDefaultApi: boolean;
-        maxRetries?: number;
-        perspective?: ClientPerspective;
-        projectId: "projectId";
-        proxy?: string;
-        requestTagPrefix?: string;
-        requester?: Required<ClientConfig>["requester"];
-        resultSourceMap?: boolean | "withKeyArraySelector";
-        retryDelay?: (attemptNumber: number) => number;
-        timeout?: number;
-        token?: string;
-        url: string;
-        useCdn: boolean;
-        useProjectHostname: boolean;
-        withCredentials?: boolean;
-      }>();
+      expectType<
+        ReturnType<typeof exec>
+      >().toStrictEqual<InitializedClientConfig>();
     });
 
     it("returns the altered type", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         }).observable;
@@ -110,7 +87,7 @@ describe("observable", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.config({
@@ -128,7 +105,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         }).observable;
@@ -136,7 +113,7 @@ describe("observable", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.withConfig({
@@ -154,7 +131,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.fetch("*");
+        }>({}).observable.fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<(AnySanityDocument & { _type: "foo"; foo: string })[]>
@@ -166,34 +143,23 @@ describe("observable", () => {
         createClient<{
           bar: { _type: "bar"; bar: "bar" };
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.fetch("*");
+        }>({}).observable.fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<(AnySanityDocument & { _type: "foo"; foo: string })[]>
       >();
     });
 
-    it("uses the client in queries", () => {
-      const exec = () =>
-        createClient()({
-          projectId: "projectId",
-        }).observable.fetch("sanity::projectId()");
-
-      expectType<ReturnType<typeof exec>>().toStrictEqual<
-        Observable<"projectId">
-      >();
-    });
-
     it("uses the params in queries", () => {
       const exec = () =>
-        createClient()({}).observable.fetch("$param", { param: "foo" });
+        createClient({}).observable.fetch("$param", { param: "foo" });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<Observable<"foo">>();
     });
 
     it("returns RawQueryResponse", () => {
       const exec = () =>
-        createClient()({}).observable.fetch("5", undefined, {
+        createClient({}).observable.fetch("5", undefined, {
           filterResponse: false,
         });
 
@@ -208,7 +174,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.listen("*");
+        }>({}).observable.listen("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -221,7 +187,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.listen("*", {}, {});
+        }>({}).observable.listen("*", {}, {});
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -237,7 +203,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.getDocument("id");
+        }>({}).observable.getDocument("id");
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Observable<
@@ -263,7 +229,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.getDocuments(["id", "id2"]);
+        }>({}).observable.getDocuments(["id", "id2"]);
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Observable<
@@ -306,7 +272,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.create>[0]>().toEqual<
           | Omit<
@@ -340,7 +306,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.createOrReplace>[0]>().toEqual<
           | Omit<
@@ -368,7 +334,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.createIfNotExists>[0]>().toEqual<
           | Omit<
@@ -400,7 +366,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.delete("id");
+        }>({}).observable.delete("id");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -418,7 +384,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.patch("id")
           .commit();
 
@@ -436,7 +402,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .set({ foo: "bar" })
             .commit();
@@ -451,7 +417,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { set: { foo: "bar" } })
             .commit();
 
@@ -467,7 +433,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .setIfMissing({ foo: "bar" })
             .commit();
@@ -482,7 +448,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { setIfMissing: { foo: "bar" } })
             .commit();
 
@@ -498,7 +464,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .diffMatchPatch({ foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" })
             .commit();
@@ -513,7 +479,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", {
               diffMatchPatch: { foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" },
             })
@@ -531,7 +497,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .unset(["foo"])
             .commit();
@@ -546,7 +512,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { unset: ["foo"] })
             .commit();
 
@@ -562,7 +528,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .inc({ foo: 1 })
             .commit();
@@ -577,7 +543,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { inc: { foo: 1 } })
             .commit();
 
@@ -593,7 +559,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .dec({ foo: 1 })
             .commit();
@@ -608,7 +574,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { dec: { foo: 1 } })
             .commit();
 
@@ -631,7 +597,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.patch("id")
           .set({ foo: "bar" })
           .reset()
@@ -654,7 +620,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.transaction()
           .commit();
 
@@ -669,7 +635,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<Parameters<typeof transaction.create>[0]>().toEqual<
             | Omit<
@@ -701,7 +667,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([{ create: { _type: "foo", foo: "foo" } }])
             .commit();
 
@@ -717,7 +683,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<
             Parameters<typeof transaction.createOrReplace>[0]
@@ -747,7 +713,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { createOrReplace: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -765,7 +731,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<
             Parameters<typeof transaction.createIfNotExists>[0]
@@ -795,7 +761,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { createIfNotExists: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -813,7 +779,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction()
             .delete("id")
             .commit();
@@ -832,7 +798,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([{ delete: { id: "id" } }])
             .commit();
 
@@ -852,7 +818,7 @@ describe("observable", () => {
           const client = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable;
+          }>({}).observable;
 
           return client
             .transaction()
@@ -870,7 +836,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction()
             .patch("id", (patch) => patch.set({ foo: "foo" }))
             .commit();
@@ -885,7 +851,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { patch: { id: "id", set: { foo: "foo" } } },
             ])
@@ -903,7 +869,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.transaction()
           .create({ _type: "foo", foo: "foo" })
           .reset()
@@ -921,7 +887,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate([]);
+        }>({}).observable.mutate([]);
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -936,9 +902,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate(
-          new ObservablePatch("id").set({ foo: "bar" })
-        );
+        }>({}).observable.mutate(new ObservablePatch("id").set({ foo: "bar" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<AnySanityDocument & { _type: "foo"; foo: string }>
@@ -950,7 +914,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate(
+        }>({}).observable.mutate(
           new ObservableTransaction().create({ _type: "foo", foo: "foo" })
         );
 

--- a/packages/client/src/stega.test.ts
+++ b/packages/client/src/stega.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import type {
-  ClientConfig,
-  ClientPerspective,
-  RequestFetchOptions,
+  InitializedClientConfig,
   SanityAssetDocument,
 } from "@sanity/client";
 import type { Observable } from "rxjs";
@@ -24,39 +22,10 @@ describe("createStegaClient", () => {
     const exec = () =>
       createStegaClient<{
         foo: AnySanityDocument & { _type: "foo"; foo: string };
-      }>()({});
+      }>({});
 
     expectType<ReturnType<typeof exec>>().toEqual<
-      SanityStegaClient<
-        { [key: string]: never },
-        AnySanityDocument & { _type: "foo"; foo: string }
-      >
-    >();
-  });
-
-  it("adds _originalId to documents when perspective is `previewDrafts`", () => {
-    const exec = () =>
-      createStegaClient<{
-        foo: AnySanityDocument & { _type: "foo"; foo: string };
-        qux: AnySanityDocument & { _type: "qux"; qux: number };
-      }>()({
-        perspective: "previewDrafts",
-      });
-
-    expectType<ReturnType<typeof exec>>().toEqual<
-      SanityStegaClient<
-        {
-          perspective: "previewDrafts";
-        },
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "foo";
-          })
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "qux";
-          })
-      >
+      SanityStegaClient<AnySanityDocument & { _type: "foo"; foo: string }>
     >();
   });
 
@@ -65,12 +34,12 @@ describe("createStegaClient", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({});
+        }>({});
 
       const execClone = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).clone();
+        }>({}).clone();
 
       expectType<ReturnType<typeof execClone>>().toEqual<
         ReturnType<typeof exec>
@@ -81,42 +50,21 @@ describe("createStegaClient", () => {
   describe("config", () => {
     it("returns the config with more", () => {
       const exec = () =>
-        createStegaClient()({
+        createStegaClient({
           dataset: "dataset",
           projectId: "projectId",
         }).config();
 
-      expectType<ReturnType<typeof exec>>().toStrictEqual<{
-        allowReconfigure?: boolean;
-        apiHost: string;
-        apiVersion: string;
-        cdnUrl: string;
-        dataset: "dataset";
-        fetch?: RequestFetchOptions | boolean;
-        ignoreBrowserTokenWarning?: boolean;
-        isDefaultApi: boolean;
-        maxRetries?: number;
-        perspective?: ClientPerspective;
-        projectId: "projectId";
-        proxy?: string;
-        requestTagPrefix?: string;
-        requester?: Required<ClientConfig>["requester"];
-        resultSourceMap?: boolean | "withKeyArraySelector";
-        retryDelay?: (attemptNumber: number) => number;
-        timeout?: number;
-        token?: string;
-        url: string;
-        useCdn: boolean;
-        useProjectHostname: boolean;
-        withCredentials?: boolean;
-      }>();
+      expectType<
+        ReturnType<typeof exec>
+      >().toStrictEqual<InitializedClientConfig>();
     });
 
     it("returns the altered type", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -124,7 +72,7 @@ describe("createStegaClient", () => {
       const execWithConfig = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).config({
@@ -142,7 +90,7 @@ describe("createStegaClient", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -150,7 +98,7 @@ describe("createStegaClient", () => {
       const execWithConfig = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).withConfig({
@@ -168,7 +116,7 @@ describe("createStegaClient", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
@@ -180,34 +128,23 @@ describe("createStegaClient", () => {
         createStegaClient<{
           bar: { _type: "bar"; bar: "bar" };
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
       >();
     });
 
-    it("uses the client in queries", () => {
-      const exec = () =>
-        createStegaClient()({
-          projectId: "projectId",
-        }).fetch("sanity::projectId()");
-
-      expectType<ReturnType<typeof exec>>().toStrictEqual<
-        Promise<"projectId">
-      >();
-    });
-
     it("uses the params in queries", () => {
       const exec = () =>
-        createStegaClient()({}).fetch("$param", { param: "foo" });
+        createStegaClient({}).fetch("$param", { param: "foo" });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<Promise<"foo">>();
     });
 
     it("returns RawQueryResponse", () => {
       const exec = () =>
-        createStegaClient()({}).fetch("5", undefined, {
+        createStegaClient({}).fetch("5", undefined, {
           filterResponse: false,
         });
 
@@ -222,7 +159,7 @@ describe("createStegaClient", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*");
+        }>({}).listen("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -235,7 +172,7 @@ describe("createStegaClient", () => {
       const exec = () =>
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*", {}, {});
+        }>({}).listen("*", {}, {});
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -251,7 +188,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocument("id");
+        }>({}).getDocument("id");
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -277,7 +214,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocuments(["id", "id2"]);
+        }>({}).getDocuments(["id", "id2"]);
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -320,7 +257,7 @@ describe("createStegaClient", () => {
         const client = createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.create>[0]>().toEqual<
           | Omit<
@@ -354,7 +291,7 @@ describe("createStegaClient", () => {
         const client = createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createOrReplace>[0]>().toEqual<
           | Omit<
@@ -382,7 +319,7 @@ describe("createStegaClient", () => {
         const client = createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createIfNotExists>[0]>().toEqual<
           | Omit<
@@ -414,7 +351,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).delete("id");
+        }>({}).delete("id");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -432,7 +369,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .commit();
 
@@ -450,7 +387,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .set({ foo: "bar" })
             .commit();
@@ -465,7 +402,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { set: { foo: "bar" } })
             .commit();
 
@@ -481,7 +418,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .setIfMissing({ foo: "bar" })
             .commit();
@@ -496,7 +433,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { setIfMissing: { foo: "bar" } })
             .commit();
 
@@ -512,7 +449,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .diffMatchPatch({ foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" })
             .commit();
@@ -527,7 +464,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", {
               diffMatchPatch: { foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" },
             })
@@ -545,7 +482,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .unset(["foo"])
             .commit();
@@ -560,7 +497,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { unset: ["foo"] })
             .commit();
 
@@ -576,7 +513,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .inc({ foo: 1 })
             .commit();
@@ -591,7 +528,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { inc: { foo: 1 } })
             .commit();
 
@@ -607,7 +544,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .dec({ foo: 1 })
             .commit();
@@ -622,7 +559,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { dec: { foo: 1 } })
             .commit();
 
@@ -645,7 +582,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .set({ foo: "bar" })
           .reset()
@@ -668,7 +605,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .commit();
 
@@ -681,7 +618,7 @@ describe("createStegaClient", () => {
           const transaction = createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<Parameters<typeof transaction.create>[0]>().toEqual<
             | Omit<
@@ -713,7 +650,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ create: { _type: "foo", foo: "foo" } }])
             .commit();
 
@@ -729,7 +666,7 @@ describe("createStegaClient", () => {
           const transaction = createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createOrReplace>[0]
@@ -759,7 +696,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createOrReplace: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -777,7 +714,7 @@ describe("createStegaClient", () => {
           const transaction = createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createIfNotExists>[0]
@@ -807,7 +744,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createIfNotExists: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -825,7 +762,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .delete("id")
             .commit();
@@ -844,7 +781,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ delete: { id: "id" } }])
             .commit();
 
@@ -864,7 +801,7 @@ describe("createStegaClient", () => {
           const client = createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({});
+          }>({});
 
           return client
             .transaction()
@@ -882,7 +819,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .patch("id", (patch) => patch.set({ foo: "foo" }))
             .commit();
@@ -897,7 +834,7 @@ describe("createStegaClient", () => {
           createStegaClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ patch: { id: "id", set: { foo: "foo" } } }])
             .commit();
 
@@ -913,7 +850,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .create({ _type: "foo", foo: "foo" })
           .reset()
@@ -929,7 +866,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([]);
+        }>({}).mutate([]);
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -944,7 +881,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([
+        }>({}).mutate([
           {
             create: {
               _type: "foo",
@@ -965,7 +902,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Patch("id").set({ foo: "bar" }));
+        }>({}).mutate(new Patch("id").set({ foo: "bar" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>
@@ -977,7 +914,7 @@ describe("createStegaClient", () => {
         createStegaClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
+        }>({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>

--- a/packages/example-app/README.md
+++ b/packages/example-app/README.md
@@ -115,9 +115,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity/client";
 import { createClient } from "@sanity-typed/client";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,

--- a/packages/example-app/src/sanity/client-with-zod.ts
+++ b/packages/example-app/src/sanity/client-with-zod.ts
@@ -4,7 +4,7 @@ import type { SanityValues } from "sanity.config";
 import { createClient } from "@sanity-typed/client";
 import { sanityConfigToZods } from "@sanity-typed/zod";
 
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,

--- a/packages/example-app/src/sanity/client.ts
+++ b/packages/example-app/src/sanity/client.ts
@@ -3,9 +3,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity/client";
 import { createClient } from "@sanity-typed/client";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,

--- a/packages/example-app/src/sanity/mocked-client.ts
+++ b/packages/example-app/src/sanity/mocked-client.ts
@@ -3,10 +3,9 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity-typed/client";
 import { createClient } from "@sanity-typed/client-mock";
 
-/** Small change using createClient */
 // export const client = createClient({
 export const client = createClient<SanityValues>({
-  dataset: [
+  documents: [
     {
       _createdAt: "2011-12-15T03:57:59.213Z",
       _id: "id",
@@ -25,7 +24,8 @@ export const client = createClient<SanityValues>({
     },
     // ...
   ],
-})({
+
+  // ...@sanity/client options
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,

--- a/packages/example-app/src/sanity/next-sanity-client.ts
+++ b/packages/example-app/src/sanity/next-sanity-client.ts
@@ -3,9 +3,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "next-sanity";
 import { createClient } from "@sanity-typed/next-sanity";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   // ...base config options
   projectId: "59t1ed5o",
   dataset: "production",

--- a/packages/example-app/src/sanity/preview-kit-client.ts
+++ b/packages/example-app/src/sanity/preview-kit-client.ts
@@ -3,9 +3,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity/preview-kit/client";
 import { createClient } from "@sanity-typed/preview-kit";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   // ...base config options
   projectId: "59t1ed5o",
   dataset: "production",

--- a/packages/example-app/src/sanity/swapping-client.ts
+++ b/packages/example-app/src/sanity/swapping-client.ts
@@ -5,16 +5,16 @@ import { createClient as createMockClient } from "@sanity-typed/client-mock";
 
 import { getMockDataset } from "./mocks";
 
-const createClient = process.env.VERCEL
-  ? createLiveClient<SanityValues>()
-  : createMockClient<SanityValues>({ dataset: getMockDataset() });
-
-export const client = createClient({
+const config = {
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,
   apiVersion: "2023-05-23",
-});
+};
+
+export const client = process.env.VERCEL
+  ? createLiveClient<SanityValues>(config)
+  : createMockClient<SanityValues>({ ...config, documents: getMockDataset() });
 
 export const makeTypedQuery = async () =>
   client.fetch('*[_type=="product"]{_id,productName,tags}');

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -20,6 +20,9 @@
   - [Types match config but not actual documents](#types-match-config-but-not-actual-documents)
   - [GROQ Query results changes in seemingly breaking ways](#groq-query-results-changes-in-seemingly-breaking-ways)
   - [`Type instantiation is excessively deep and possibly infinite`](#type-instantiation-is-excessively-deep-and-possibly-infinite)
+- [Breaking Changes](#breaking-changes)
+  - [1 to 2](#1-to-2)
+    - [No more `createClient<SanityValues>()(config)`](#no-more-createclientsanityvaluesconfig)
 
 ## Install
 
@@ -131,9 +134,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "next-sanity";
 import { createClient } from "@sanity-typed/next-sanity";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   // ...base config options
   projectId: "59t1ed5o",
   dataset: "production",
@@ -213,4 +215,21 @@ You might run into the dreaded `Type instantiation is excessively deep and possi
 
 People will sometimes create a repo with their issue. _Please_ open a PR with a minimal test instead. Without a PR there will be no tests reflecting your issue and it may appear again in a regression. Forking a github repo to make a PR is a more welcome way to contribute to an open source library.
 <!-- <<<<<< END INCLUDED FILE (markdown): SOURCE docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md -->
+
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 <!-- <<<<<< END GENERATED FILE (include): SOURCE packages/next-sanity/_README.md -->

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -231,5 +231,5 @@ Removing the double function signature from `createClient`:
 });
 ```
 
-This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 <!-- <<<<<< END GENERATED FILE (include): SOURCE packages/next-sanity/_README.md -->

--- a/packages/next-sanity/_README.md
+++ b/packages/next-sanity/_README.md
@@ -33,3 +33,20 @@ Use `createClient` exactly as you would from [`@sanity-typed/client`](../client)
 @[:markdown](../../docs/considerations/types-vs-content-lake.md)
 @[:markdown](../../docs/considerations/evaluate-type-flakiness.md)
 @[:markdown](../../docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md)
+
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.

--- a/packages/next-sanity/src/index.test.ts
+++ b/packages/next-sanity/src/index.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import type {
-  ClientConfig,
-  ClientPerspective,
-  RequestFetchOptions,
+  InitializedClientConfig,
   SanityAssetDocument,
 } from "@sanity/client";
 import type { Observable } from "rxjs";
@@ -25,39 +23,10 @@ describe("createClient", () => {
     const exec = () =>
       createClient<{
         foo: AnySanityDocument & { _type: "foo"; foo: string };
-      }>()({});
+      }>({});
 
     expectType<ReturnType<typeof exec>>().toEqual<
-      SanityClient<
-        { [key: string]: never },
-        AnySanityDocument & { _type: "foo"; foo: string }
-      >
-    >();
-  });
-
-  it("adds _originalId to documents when perspective is `previewDrafts`", () => {
-    const exec = () =>
-      createClient<{
-        foo: AnySanityDocument & { _type: "foo"; foo: string };
-        qux: AnySanityDocument & { _type: "qux"; qux: number };
-      }>()({
-        perspective: "previewDrafts",
-      });
-
-    expectType<ReturnType<typeof exec>>().toEqual<
-      SanityClient<
-        {
-          perspective: "previewDrafts";
-        },
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "foo";
-          })
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "qux";
-          })
-      >
+      SanityClient<AnySanityDocument & { _type: "foo"; foo: string }>
     >();
   });
 
@@ -66,12 +35,12 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({});
+        }>({});
 
       const execClone = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).clone();
+        }>({}).clone();
 
       expectType<ReturnType<typeof execClone>>().toEqual<
         ReturnType<typeof exec>
@@ -82,42 +51,21 @@ describe("createClient", () => {
   describe("config", () => {
     it("returns the config with more", () => {
       const exec = () =>
-        createClient()({
+        createClient({
           dataset: "dataset",
           projectId: "projectId",
         }).config();
 
-      expectType<ReturnType<typeof exec>>().toStrictEqual<{
-        allowReconfigure?: boolean;
-        apiHost: string;
-        apiVersion: string;
-        cdnUrl: string;
-        dataset: "dataset";
-        fetch?: RequestFetchOptions | boolean;
-        ignoreBrowserTokenWarning?: boolean;
-        isDefaultApi: boolean;
-        maxRetries?: number;
-        perspective?: ClientPerspective;
-        projectId: "projectId";
-        proxy?: string;
-        requestTagPrefix?: string;
-        requester?: Required<ClientConfig>["requester"];
-        resultSourceMap?: boolean | "withKeyArraySelector";
-        retryDelay?: (attemptNumber: number) => number;
-        timeout?: number;
-        token?: string;
-        url: string;
-        useCdn: boolean;
-        useProjectHostname: boolean;
-        withCredentials?: boolean;
-      }>();
+      expectType<
+        ReturnType<typeof exec>
+      >().toStrictEqual<InitializedClientConfig>();
     });
 
     it("returns the altered type", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -125,7 +73,7 @@ describe("createClient", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).config({
@@ -143,7 +91,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         });
@@ -151,7 +99,7 @@ describe("createClient", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).withConfig({
@@ -169,7 +117,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
@@ -181,33 +129,22 @@ describe("createClient", () => {
         createClient<{
           bar: { _type: "bar"; bar: "bar" };
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).fetch("*");
+        }>({}).fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<(AnySanityDocument & { _type: "foo"; foo: string })[]>
       >();
     });
 
-    it("uses the client in queries", () => {
-      const exec = () =>
-        createClient()({
-          projectId: "projectId",
-        }).fetch("sanity::projectId()");
-
-      expectType<ReturnType<typeof exec>>().toStrictEqual<
-        Promise<"projectId">
-      >();
-    });
-
     it("uses the params in queries", () => {
-      const exec = () => createClient()({}).fetch("$param", { param: "foo" });
+      const exec = () => createClient({}).fetch("$param", { param: "foo" });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<Promise<"foo">>();
     });
 
     it("returns RawQueryResponse", () => {
       const exec = () =>
-        createClient()({}).fetch("5", undefined, { filterResponse: false });
+        createClient({}).fetch("5", undefined, { filterResponse: false });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<RawQueryResponse<5, "5">>
@@ -220,7 +157,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*");
+        }>({}).listen("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -233,7 +170,7 @@ describe("createClient", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).listen("*", {}, {});
+        }>({}).listen("*", {}, {});
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -249,7 +186,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocument("id");
+        }>({}).getDocument("id");
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -275,7 +212,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).getDocuments(["id", "id2"]);
+        }>({}).getDocuments(["id", "id2"]);
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Promise<
@@ -318,7 +255,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.create>[0]>().toEqual<
           | Omit<
@@ -352,7 +289,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createOrReplace>[0]>().toEqual<
           | Omit<
@@ -380,7 +317,7 @@ describe("createClient", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({});
+        }>({});
 
         expectType<Parameters<typeof client.createIfNotExists>[0]>().toEqual<
           | Omit<
@@ -412,7 +349,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).delete("id");
+        }>({}).delete("id");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -430,7 +367,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .commit();
 
@@ -448,7 +385,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .set({ foo: "bar" })
             .commit();
@@ -463,7 +400,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { set: { foo: "bar" } })
             .commit();
 
@@ -479,7 +416,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .setIfMissing({ foo: "bar" })
             .commit();
@@ -494,7 +431,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { setIfMissing: { foo: "bar" } })
             .commit();
 
@@ -510,7 +447,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .diffMatchPatch({ foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" })
             .commit();
@@ -525,7 +462,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", {
               diffMatchPatch: { foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" },
             })
@@ -543,7 +480,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .unset(["foo"])
             .commit();
@@ -558,7 +495,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { unset: ["foo"] })
             .commit();
 
@@ -574,7 +511,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .inc({ foo: 1 })
             .commit();
@@ -589,7 +526,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { inc: { foo: 1 } })
             .commit();
 
@@ -605,7 +542,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id")
             .dec({ foo: 1 })
             .commit();
@@ -620,7 +557,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .patch("id", { dec: { foo: 1 } })
             .commit();
 
@@ -643,7 +580,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .patch("id")
           .set({ foo: "bar" })
           .reset()
@@ -666,7 +603,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .commit();
 
@@ -679,7 +616,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<Parameters<typeof transaction.create>[0]>().toEqual<
             | Omit<
@@ -711,7 +648,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ create: { _type: "foo", foo: "foo" } }])
             .commit();
 
@@ -727,7 +664,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createOrReplace>[0]
@@ -757,7 +694,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createOrReplace: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -775,7 +712,7 @@ describe("createClient", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).transaction();
+          }>({}).transaction();
 
           expectType<
             Parameters<typeof transaction.createIfNotExists>[0]
@@ -805,7 +742,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([
               { createIfNotExists: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -823,7 +760,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .delete("id")
             .commit();
@@ -842,7 +779,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ delete: { id: "id" } }])
             .commit();
 
@@ -862,7 +799,7 @@ describe("createClient", () => {
           const client = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({});
+          }>({});
 
           return client
             .transaction()
@@ -880,7 +817,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction()
             .patch("id", (patch) => patch.set({ foo: "foo" }))
             .commit();
@@ -895,7 +832,7 @@ describe("createClient", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .transaction([{ patch: { id: "id", set: { foo: "foo" } } }])
             .commit();
 
@@ -911,7 +848,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .transaction()
           .create({ _type: "foo", foo: "foo" })
           .reset()
@@ -927,7 +864,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([]);
+        }>({}).mutate([]);
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<
@@ -942,7 +879,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate([
+        }>({}).mutate([
           {
             create: {
               _type: "foo",
@@ -963,7 +900,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Patch("id").set({ foo: "bar" }));
+        }>({}).mutate(new Patch("id").set({ foo: "bar" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>
@@ -975,7 +912,7 @@ describe("createClient", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
+        }>({}).mutate(new Transaction().create({ _type: "foo", foo: "foo" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Promise<AnySanityDocument & { _type: "foo"; foo: string }>

--- a/packages/next-sanity/src/internal.ts
+++ b/packages/next-sanity/src/internal.ts
@@ -1,33 +1,19 @@
 import type { ClientConfig } from "next-sanity";
 import { createClient as createClientNative } from "next-sanity";
 
-import type {
-  SanityClient as SanityClientNative,
-  SanityStegaClient,
-} from "@sanity-typed/client";
-import type { SanityValuesToDocumentUnion } from "@sanity-typed/client/src/internal";
+import type { SanityStegaClient } from "@sanity-typed/client";
+import type { DocumentValues } from "@sanity-typed/types";
 import type { AnySanityDocument } from "@sanity-typed/types/src/internal";
 
-export type SanityClient<
-  TClientConfig extends ClientConfig,
-  TDocument extends AnySanityDocument
-> =
-  | SanityClientNative<TClientConfig, TDocument>
-  | SanityStegaClient<TClientConfig, TDocument>;
+export type SanityClient<TDocument extends AnySanityDocument> =
+  SanityStegaClient<TDocument>;
 
-export type ObservableSanityClient<
-  TClientConfig extends ClientConfig,
-  TDocument extends AnySanityDocument
-> = SanityClient<TClientConfig, TDocument>["observable"];
+export type ObservableSanityClient<TDocument extends AnySanityDocument> =
+  SanityClient<TDocument>["observable"];
 
-/**
- * Unfortunately, this has to have a very weird function signature due to this typescript issue:
- * https://github.com/microsoft/TypeScript/issues/10571
- */
-export const createClient =
-  <SanityValues extends { [type: string]: any }>() =>
-  <const TClientConfig extends ClientConfig>(config: TClientConfig) =>
-    createClientNative(config) as unknown as SanityClient<
-      TClientConfig,
-      SanityValuesToDocumentUnion<SanityValues, TClientConfig>
-    >;
+export const createClient = <SanityValues extends { [type: string]: any }>(
+  config: ClientConfig
+) =>
+  createClientNative(config) as unknown as SanityClient<
+    DocumentValues<SanityValues>
+  >;

--- a/packages/next-sanity/src/observable.test.ts
+++ b/packages/next-sanity/src/observable.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@jest/globals";
 import { expectType } from "@saiichihashimoto/test-utils";
 import type {
-  ClientConfig,
-  ClientPerspective,
-  RequestFetchOptions,
+  InitializedClientConfig,
   SanityAssetDocument,
 } from "@sanity/client";
 import type { Observable } from "rxjs";
@@ -18,46 +16,19 @@ import type {
 import type { AnySanityDocument } from "@sanity-typed/types/src/internal";
 
 import { createClient } from ".";
-import type { ObservableSanityClient } from ".";
 
 describe("observable", () => {
-  it("adds _originalId to documents when perspective is `previewDrafts`", () => {
-    const exec = () =>
-      createClient<{
-        foo: AnySanityDocument & { _type: "foo"; foo: string };
-        qux: AnySanityDocument & { _type: "qux"; qux: number };
-      }>()({
-        perspective: "previewDrafts",
-      }).observable;
-
-    expectType<ReturnType<typeof exec>>().toEqual<
-      ObservableSanityClient<
-        {
-          perspective: "previewDrafts";
-        },
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "foo";
-          })
-        | (AnySanityDocument & {
-            _originalId: string;
-            _type: "qux";
-          })
-      >
-    >();
-  });
-
   describe("clone", () => {
     it("returns the same type", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable;
+        }>({}).observable;
 
       const execClone = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.clone();
+        }>({}).observable.clone();
 
       expectType<ReturnType<typeof execClone>>().toEqual<
         ReturnType<typeof exec>
@@ -68,42 +39,21 @@ describe("observable", () => {
   describe("config", () => {
     it("returns the config with more", () => {
       const exec = () =>
-        createClient()({
+        createClient({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.config();
 
-      expectType<ReturnType<typeof exec>>().toStrictEqual<{
-        allowReconfigure?: boolean;
-        apiHost: string;
-        apiVersion: string;
-        cdnUrl: string;
-        dataset: "dataset";
-        fetch?: RequestFetchOptions | boolean;
-        ignoreBrowserTokenWarning?: boolean;
-        isDefaultApi: boolean;
-        maxRetries?: number;
-        perspective?: ClientPerspective;
-        projectId: "projectId";
-        proxy?: string;
-        requestTagPrefix?: string;
-        requester?: Required<ClientConfig>["requester"];
-        resultSourceMap?: boolean | "withKeyArraySelector";
-        retryDelay?: (attemptNumber: number) => number;
-        timeout?: number;
-        token?: string;
-        url: string;
-        useCdn: boolean;
-        useProjectHostname: boolean;
-        withCredentials?: boolean;
-      }>();
+      expectType<
+        ReturnType<typeof exec>
+      >().toStrictEqual<InitializedClientConfig>();
     });
 
     it("returns the altered type", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         }).observable;
@@ -111,7 +61,7 @@ describe("observable", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.config({
@@ -129,7 +79,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "newProjectId",
         }).observable;
@@ -137,7 +87,7 @@ describe("observable", () => {
       const execWithConfig = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({
+        }>({
           dataset: "dataset",
           projectId: "projectId",
         }).observable.withConfig({
@@ -155,7 +105,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.fetch("*");
+        }>({}).observable.fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<(AnySanityDocument & { _type: "foo"; foo: string })[]>
@@ -167,34 +117,23 @@ describe("observable", () => {
         createClient<{
           bar: { _type: "bar"; bar: "bar" };
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.fetch("*");
+        }>({}).observable.fetch("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<(AnySanityDocument & { _type: "foo"; foo: string })[]>
       >();
     });
 
-    it("uses the client in queries", () => {
-      const exec = () =>
-        createClient()({
-          projectId: "projectId",
-        }).observable.fetch("sanity::projectId()");
-
-      expectType<ReturnType<typeof exec>>().toStrictEqual<
-        Observable<"projectId">
-      >();
-    });
-
     it("uses the params in queries", () => {
       const exec = () =>
-        createClient()({}).observable.fetch("$param", { param: "foo" });
+        createClient({}).observable.fetch("$param", { param: "foo" });
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<Observable<"foo">>();
     });
 
     it("returns RawQueryResponse", () => {
       const exec = () =>
-        createClient()({}).observable.fetch("5", undefined, {
+        createClient({}).observable.fetch("5", undefined, {
           filterResponse: false,
         });
 
@@ -209,7 +148,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.listen("*");
+        }>({}).observable.listen("*");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -222,7 +161,7 @@ describe("observable", () => {
       const exec = () =>
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
-        }>()({}).observable.listen("*", {}, {});
+        }>({}).observable.listen("*", {}, {});
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -238,7 +177,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.getDocument("id");
+        }>({}).observable.getDocument("id");
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Observable<
@@ -264,7 +203,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.getDocuments(["id", "id2"]);
+        }>({}).observable.getDocuments(["id", "id2"]);
 
       expectType<ReturnType<typeof exec>>().toEqual<
         Observable<
@@ -307,7 +246,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.create>[0]>().toEqual<
           | Omit<
@@ -341,7 +280,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.createOrReplace>[0]>().toEqual<
           | Omit<
@@ -369,7 +308,7 @@ describe("observable", () => {
         const client = createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable;
+        }>({}).observable;
 
         expectType<Parameters<typeof client.createIfNotExists>[0]>().toEqual<
           | Omit<
@@ -401,7 +340,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.delete("id");
+        }>({}).observable.delete("id");
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -419,7 +358,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.patch("id")
           .commit();
 
@@ -437,7 +376,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .set({ foo: "bar" })
             .commit();
@@ -452,7 +391,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { set: { foo: "bar" } })
             .commit();
 
@@ -468,7 +407,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .setIfMissing({ foo: "bar" })
             .commit();
@@ -483,7 +422,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { setIfMissing: { foo: "bar" } })
             .commit();
 
@@ -499,7 +438,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .diffMatchPatch({ foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" })
             .commit();
@@ -514,7 +453,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", {
               diffMatchPatch: { foo: "@@ -1,3 +1,3 @@\n-foo\n+bar\n" },
             })
@@ -532,7 +471,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .unset(["foo"])
             .commit();
@@ -547,7 +486,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo?: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { unset: ["foo"] })
             .commit();
 
@@ -563,7 +502,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .inc({ foo: 1 })
             .commit();
@@ -578,7 +517,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { inc: { foo: 1 } })
             .commit();
 
@@ -594,7 +533,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id")
             .dec({ foo: 1 })
             .commit();
@@ -609,7 +548,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: number };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.patch("id", { dec: { foo: 1 } })
             .commit();
 
@@ -632,7 +571,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.patch("id")
           .set({ foo: "bar" })
           .reset()
@@ -655,7 +594,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.transaction()
           .commit();
 
@@ -670,7 +609,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<Parameters<typeof transaction.create>[0]>().toEqual<
             | Omit<
@@ -702,7 +641,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([{ create: { _type: "foo", foo: "foo" } }])
             .commit();
 
@@ -718,7 +657,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<
             Parameters<typeof transaction.createOrReplace>[0]
@@ -748,7 +687,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { createOrReplace: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -766,7 +705,7 @@ describe("observable", () => {
           const transaction = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable.transaction();
+          }>({}).observable.transaction();
 
           expectType<
             Parameters<typeof transaction.createIfNotExists>[0]
@@ -796,7 +735,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { createIfNotExists: { _type: "foo", _id: "id", foo: "foo" } },
             ])
@@ -814,7 +753,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction()
             .delete("id")
             .commit();
@@ -833,7 +772,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([{ delete: { id: "id" } }])
             .commit();
 
@@ -853,7 +792,7 @@ describe("observable", () => {
           const client = createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({}).observable;
+          }>({}).observable;
 
           return client
             .transaction()
@@ -871,7 +810,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction()
             .patch("id", (patch) => patch.set({ foo: "foo" }))
             .commit();
@@ -886,7 +825,7 @@ describe("observable", () => {
           createClient<{
             foo: AnySanityDocument & { _type: "foo"; foo: string };
             qux: AnySanityDocument & { _type: "qux"; qux: number };
-          }>()({})
+          }>({})
             .observable.transaction([
               { patch: { id: "id", set: { foo: "foo" } } },
             ])
@@ -904,7 +843,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({})
+        }>({})
           .observable.transaction()
           .create({ _type: "foo", foo: "foo" })
           .reset()
@@ -922,7 +861,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate([]);
+        }>({}).observable.mutate([]);
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<
@@ -937,9 +876,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate(
-          new ObservablePatch("id").set({ foo: "bar" })
-        );
+        }>({}).observable.mutate(new ObservablePatch("id").set({ foo: "bar" }));
 
       expectType<ReturnType<typeof exec>>().toStrictEqual<
         Observable<AnySanityDocument & { _type: "foo"; foo: string }>
@@ -951,7 +888,7 @@ describe("observable", () => {
         createClient<{
           foo: AnySanityDocument & { _type: "foo"; foo: string };
           qux: AnySanityDocument & { _type: "qux"; qux: number };
-        }>()({}).observable.mutate(
+        }>({}).observable.mutate(
           new ObservableTransaction().create({ _type: "foo", foo: "foo" })
         );
 

--- a/packages/preview-kit/README.md
+++ b/packages/preview-kit/README.md
@@ -231,5 +231,5 @@ Removing the double function signature from `createClient`:
 });
 ```
 
-This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 <!-- <<<<<< END GENERATED FILE (include): SOURCE packages/preview-kit/_README.md -->

--- a/packages/preview-kit/README.md
+++ b/packages/preview-kit/README.md
@@ -20,6 +20,9 @@
   - [Types match config but not actual documents](#types-match-config-but-not-actual-documents)
   - [GROQ Query results changes in seemingly breaking ways](#groq-query-results-changes-in-seemingly-breaking-ways)
   - [`Type instantiation is excessively deep and possibly infinite`](#type-instantiation-is-excessively-deep-and-possibly-infinite)
+- [Breaking Changes](#breaking-changes)
+  - [1 to 2](#1-to-2)
+    - [No more `createClient<SanityValues>()(config)`](#no-more-createclientsanityvaluesconfig)
 
 ## Install
 
@@ -131,9 +134,8 @@ import type { SanityValues } from "sanity.config";
 // import { createClient } from "@sanity/preview-kit/client";
 import { createClient } from "@sanity-typed/preview-kit";
 
-/** Small change using createClient */
 // export const client = createClient({
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   // ...base config options
   projectId: "59t1ed5o",
   dataset: "production",
@@ -213,4 +215,21 @@ You might run into the dreaded `Type instantiation is excessively deep and possi
 
 People will sometimes create a repo with their issue. _Please_ open a PR with a minimal test instead. Without a PR there will be no tests reflecting your issue and it may appear again in a regression. Forking a github repo to make a PR is a more welcome way to contribute to an open source library.
 <!-- <<<<<< END INCLUDED FILE (markdown): SOURCE docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md -->
+
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+This removes any typing that would have come from specific config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.
 <!-- <<<<<< END GENERATED FILE (include): SOURCE packages/preview-kit/_README.md -->

--- a/packages/preview-kit/_README.md
+++ b/packages/preview-kit/_README.md
@@ -33,3 +33,20 @@ Use `createClient` exactly as you would from [`@sanity-typed/client`](../client)
 @[:markdown](../../docs/considerations/types-vs-content-lake.md)
 @[:markdown](../../docs/considerations/evaluate-type-flakiness.md)
 @[:markdown](../../docs/considerations/type-instantiation-is-excessively-deep-and-possibly-infinite-query.md)
+
+## Breaking Changes
+
+### 1 to 2
+
+#### No more `createClient<SanityValues>()(config)`
+
+Removing the double function signature from `createClient`:
+
+```diff
+- const client = createClient<SanityValues>()({
++ const client = createClient<SanityValues>({
+  // ...
+});
+```
+
+We no longer derive types from your config values. Most of the types weren't significant, but the main loss will be `_originalId` when the `perspective` was `"previewDrafts"`.

--- a/packages/preview-kit/src/internal.ts
+++ b/packages/preview-kit/src/internal.ts
@@ -1,22 +1,12 @@
 import { createClient as createClientNative } from "@sanity/preview-kit/client";
 import type { PreviewKitClientConfig } from "@sanity/preview-kit/client";
 
-import type { SanityClient, SanityStegaClient } from "@sanity-typed/client";
-import type { SanityValuesToDocumentUnion } from "@sanity-typed/client/src/internal";
+import type { SanityStegaClient } from "@sanity-typed/client";
+import type { DocumentValues } from "@sanity-typed/types";
 
-/**
- * Unfortunately, this has to have a very weird function signature due to this typescript issue:
- * https://github.com/microsoft/TypeScript/issues/10571
- */
-export const createClient =
-  <SanityValues extends { [type: string]: any }>() =>
-  <const TClientConfig extends PreviewKitClientConfig>(config: TClientConfig) =>
-    createClientNative(config) as unknown as
-      | SanityClient<
-          TClientConfig,
-          SanityValuesToDocumentUnion<SanityValues, TClientConfig>
-        >
-      | SanityStegaClient<
-          TClientConfig,
-          SanityValuesToDocumentUnion<SanityValues, TClientConfig>
-        >;
+export const createClient = <SanityValues extends { [type: string]: any }>(
+  config: PreviewKitClientConfig
+) =>
+  createClientNative(config) as unknown as SanityStegaClient<
+    DocumentValues<SanityValues>
+  >;

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -133,7 +133,7 @@ import type { SanityValues } from "sanity.config";
 import { createClient } from "@sanity-typed/client";
 import { sanityConfigToZods } from "@sanity-typed/zod";
 
-export const client = createClient<SanityValues>()({
+export const client = createClient<SanityValues>({
   projectId: "59t1ed5o",
   dataset: "production",
   useCdn: true,


### PR DESCRIPTION
BREAKING CHANGE: createClient no longer uses the double function signature