### PR TITLE
dont start tests for not-built packages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -234,7 +234,7 @@ jobs:
 
       - id: set-packages
         run: |
-          echo "packages=$(npx turbo run build --dry=json | jq --compact-output '.tasks | map(.taskId | sub("@portabletext-typed/types"; "pt-types") | sub("@portabletext-typed/"; "") | sub("@sanity-typed/"; "") | sub("#build"; ""))')" >> $GITHUB_OUTPUT
+          echo "packages=$(npx turbo run build --dry=json | jq --compact-output '.tasks | map(select(.command != "<NONEXISTENT>")) | map(.taskId | sub("@portabletext-typed/types"; "pt-types") | sub("@portabletext-typed/"; "") | sub("@sanity-typed/"; "") | sub("#build"; ""))')" >> $GITHUB_OUTPUT
 
       - id: set-typescript-versions
         run: |


### PR DESCRIPTION
We'll have to change this if we ever run tests for them