### PR TITLE
fix(types): strike decorator is deprecated, use strike-through

### DIFF
--- a/packages/faker/src/internal.ts
+++ b/packages/faker/src/internal.ts
@@ -976,8 +976,6 @@ const spanFaker =
               () => "em",
               () => "code",
               () => "underline",
-              // TODO https://github.com/sanity-io/sanity/issues/5344
-              () => "strike",
               () => "strike-through",
             ]),
           ],

--- a/packages/pt-react/src/internal.ts
+++ b/packages/pt-react/src/internal.ts
@@ -26,9 +26,7 @@ import type { MaybeArray } from "@sanity-typed/utils";
 type BlockMarkDecoratorDefault =
   | "code"
   | "em"
-  // TODO https://github.com/sanity-io/sanity/issues/5344
   | "strike-through"
-  | "strike"
   | "strong"
   | "underline";
 

--- a/packages/pt-to-html/src/internal.ts
+++ b/packages/pt-to-html/src/internal.ts
@@ -32,9 +32,7 @@ type MergeOld<FirstType, SecondType> = Except<
 type BlockMarkDecoratorDefault =
   | "code"
   | "em"
-  // TODO https://github.com/sanity-io/sanity/issues/5344
   | "strike-through"
-  | "strike"
   | "strong"
   | "underline";
 

--- a/packages/pt-types/src/internal.ts
+++ b/packages/pt-types/src/internal.ts
@@ -7,9 +7,7 @@ import type { SetRequired } from "type-fest";
 export type BlockMarkDecoratorDefault =
   | "code"
   | "em"
-  // TODO https://github.com/sanity-io/sanity/issues/5344
   | "strike-through"
-  | "strike"
   | "strong"
   | "underline";
 

--- a/packages/types/src/block.test.ts
+++ b/packages/types/src/block.test.ts
@@ -38,7 +38,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -115,7 +114,6 @@ describe("block", () => {
                 | "code"
                 | "em"
                 | "strike-through"
-                | "strike"
                 | "strong"
                 | "underline";
               marks: string[];
@@ -172,7 +170,6 @@ describe("block", () => {
                 | "code"
                 | "em"
                 | "strike-through"
-                | "strike"
                 | "strong"
                 | "underline";
               marks: string[];
@@ -229,7 +226,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -275,7 +271,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -390,7 +385,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -448,7 +442,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -494,7 +487,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -609,7 +601,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -687,7 +678,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -762,7 +752,6 @@ describe("block", () => {
                 | "code"
                 | "em"
                 | "strike-through"
-                | "strike"
                 | "strong"
                 | "underline";
               marks: string[];
@@ -813,7 +802,6 @@ describe("block", () => {
                 | "code"
                 | "em"
                 | "strike-through"
-                | "strike"
                 | "strong"
                 | "underline";
               marks: string[];
@@ -864,7 +852,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -904,7 +891,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -1007,7 +993,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -1059,7 +1044,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -1099,7 +1083,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -1202,7 +1185,6 @@ describe("block", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];

--- a/packages/types/src/specific-issues.test.ts
+++ b/packages/types/src/specific-issues.test.ts
@@ -151,7 +151,6 @@ describe("specific issues", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];
@@ -225,7 +224,6 @@ describe("specific issues", () => {
             | "code"
             | "em"
             | "strike-through"
-            | "strike"
             | "strong"
             | "underline";
           marks: string[];


### PR DESCRIPTION
https://github.com/sanity-io/sanity/pull/10416